### PR TITLE
Beaker jobs should be canceled if Jenkins job fails/canceled by user

### DIFF
--- a/MVP/defaults-build.yaml
+++ b/MVP/defaults-build.yaml
@@ -15,10 +15,9 @@
               - shell: |
                   #!/bin/bash
                   echo "Jenkins job failed or canceled - canceling any submitted Beaker jobs"
-                  BKR_JOBID=`cut -d\' -f2 $WORKSPACE/bkr_job.txt`
                   bkr job-cancel ${{BKR_JOBID}}
         - archive:
-            artifacts: '*.txt, *.xml'
+            artifacts: '*.txt, *.xml, *.properties'
             allow-empty: 'true'
         - junit:
             results: 'J:*.xml'

--- a/MVP/defaults-build.yaml
+++ b/MVP/defaults-build.yaml
@@ -8,6 +8,15 @@
         - build-name:
             name: ${{ENV,var="name"}}-${{ENV,var="version"}}-${{ENV,var="release"}}
     publishers:
+        - postbuildscript:
+          script-only-if-succeeded: False
+          script-only-if-failed: True
+          builders:
+            - shell: |
+                #!/bin/bash
+                echo "Jenkins job failed or canceled - canceling any submitted Beaker jobs"
+                BKR_JOBID=`cut -d\' -f2 $WORKSPACE/bkr_job.txt`
+                bkr job-cancel ${{BKR_JOBID}}
         - archive:
             artifacts: '*.txt, *.xml'
             allow-empty: 'true'

--- a/MVP/defaults-build.yaml
+++ b/MVP/defaults-build.yaml
@@ -9,14 +9,14 @@
             name: ${{ENV,var="name"}}-${{ENV,var="version"}}-${{ENV,var="release"}}
     publishers:
         - postbuildscript:
-          script-only-if-succeeded: False
-          script-only-if-failed: True
-          builders:
-            - shell: |
-                #!/bin/bash
-                echo "Jenkins job failed or canceled - canceling any submitted Beaker jobs"
-                BKR_JOBID=`cut -d\' -f2 $WORKSPACE/bkr_job.txt`
-                bkr job-cancel ${{BKR_JOBID}}
+            script-only-if-succeeded: False
+            script-only-if-failed: True
+            builders:
+              - shell: |
+                  #!/bin/bash
+                  echo "Jenkins job failed or canceled - canceling any submitted Beaker jobs"
+                  BKR_JOBID=`cut -d\' -f2 $WORKSPACE/bkr_job.txt`
+                  bkr job-cancel ${{BKR_JOBID}}
         - archive:
             artifacts: '*.txt, *.xml'
             allow-empty: 'true'

--- a/MVP/sample_job.yaml
+++ b/MVP/sample_job.yaml
@@ -14,7 +14,13 @@
             # Here goes your shell commands for submitting beaker job here, and save the job ID into env var BKR_JOBID. E.g:
             bkr job-submit $YOUR_TEST_xml | tee $WORKSPACE/bkr_job.txt
             BKR_JOBID=`cut -d\' -f2 $WORKSPACE/bkr_job.txt`
-
+            echo "BKR_JOBID=$BKR_JOBID" > $WORKSPACE/job.properties
+        - inject:
+            # Saving the Beaker job IDs to file job.properties
+            properties-file: $WORKSPACE/job.properties
+        - shell: |
+            #!/bin/bash -x
+            # Here goes the shell command to watch your Beaker jobs and format results on completion
             bkr job-watch $BKR_JOBID
             bkr job-results --format junit-xml $BKR_JOBID > $WORKSPACE/$BKR_JOBID.xml
 


### PR DESCRIPTION
As discussed in issue #10, here is a proposed solution.  It is like a "teardown" step that other CI frameworks use.
