### PR TITLE
Build-on-Push: Migrating from the internal repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.project
+.pydevproject
+.settings/
+build-on-push/.lock-waf_linux2_build
+build-on-push/build
+*.pyc

--- a/build-on-push/.pylint
+++ b/build-on-push/.pylint
@@ -1,0 +1,311 @@
+[MASTER]
+
+# Specify a configuration file.
+#rcfile=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+[MESSAGES CONTROL]
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time. See also the "--disable" option for examples.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=missing-docstring,locally-disabled,fixme
+
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]".
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_$|dummy
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis
+ignored-modules=
+
+# List of classes names for which member attributes should not be checked
+# (useful for classes with attributes dynamically set).
+ignored-classes=SQLObject
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E0201 when accessed. Python regular
+# expressions are accepted.
+generated-members=REQUEST,acl_users,aq_parent
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=120
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+# List of optional constructs for which whitespace checking is disabled
+no-space-check=trailing-comma,dict-separator
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[BASIC]
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=map,filter,apply,input,file
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_,qe
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Regular expression matching correct function names
+function-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for function names
+function-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct variable names
+variable-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for variable names
+variable-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Za-z_][A-Za-z0-9_]*)|(__.*__))$
+
+# Naming hint for constant names
+const-name-hint=(([A-Za-z_][A-Za-z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct attribute names
+attr-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for attribute names
+attr-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct argument names
+argument-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for argument names
+argument-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Naming hint for class attribute names
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming hint for class names
+class-name-hint=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Naming hint for module names
+module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression matching correct method names
+method-rgx=([a-z_][a-z0-9_]{2,30})|([a-z_][a-z0-9_]+_test)$
+
+# Naming hint for method names
+method-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=__.*__
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=6
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,TERMIOS,Bastion,rexec
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/build-on-push/LICENSE
+++ b/build-on-push/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/build-on-push/README.md
+++ b/build-on-push/README.md
@@ -1,0 +1,30 @@
+# Build-on-Push Infrastructure
+
+## Deployment
+
+### Component setup job deployment
+
+### Jenkins Configuration
+
+To fully work, several system-wide environmental variables need to be set on your Jenkins:
+
+ * **BOP_DIST_GIT_URL**: A prefix for constructing git repository URLs
+ * **BOP_JENKINS_CLI**: A path (with parameters) where Jenkins CLI is present on Build-on-Push slaves
+ * **PLATFORM_CI_ADMINS**: A list of names/email addresses with the Jenkins instance admin contacts
+
+You can configure several other variables; they will improve some job and build descriptions by providing links
+to other useful content. If not present, such links will not be provided:
+
+ * **BOP_STAGING_BRANCH_DOC**: A URL to the Staging branch documentation
+ * **PLATFORM_CI_BUG_DESTINATION**: A URL to a destination where users can file their bugs and requests
+ * **PLATFORM_CI_PROJECT_PAGE**: A URL to a CI project page
+
+
+### Slave Configuration
+
+The slaves executing the Build-on-Push jobs need the have the following configuration:
+
+ * A Jenkins CLI must be present on the location specified by the master's **BOP_JENKINS_CLI** variable
+ * The slave needs to have a private key allowing some Jenkins user to login and create/trigger/update jobs and builds. It is best to use a special key pair for this.
+ * The **rhpkg** tool needs to be installed
+ * The Jenkins Job Buider needs to be installed

--- a/build-on-push/jjb/platform-commit.yaml
+++ b/build-on-push/jjb/platform-commit.yaml
@@ -1,0 +1,159 @@
+# Copyright 2016 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Template parameters:
+#   * component: A name of a component for which this job is set up
+#   * team-slave: A slave on which this job should run
+#   * display-name: A human readable description of this job
+#   * github-user: A GitHub user whose fork of 'platform-ci' will be used by the generated jobs
+#   * platform-ci-branch: A branch of Platform CI repo from which the support
+#       code is fetched
+#   * staging-branch-doc-link: An <a></a> tag pair with a link to the staging
+#       branch documentation.
+#   * platform-ci-project-link: An <a></a> tag pair with a link to the
+#       Platform CI project homepage
+#   * distgit-root-url: A URL to the DistGit root
+
+- defaults:
+    name: 'ci-dispatcher-commit'
+    description: |
+        <p>This job is triggered whenever there are new commits in dist-git
+        repository for the <strong>'{component}'</strong> component. The
+        repository is polled approximately once per ten minutes. If a branch is
+        a {staging-branch-doc-link}, or if the branch contains a
+        <strong>ci.yaml</strong> file, a worker job will be triggered. A worker
+        job then issues a Brew scratch build from the code in the changed
+        branch.</p>
+
+        <p><strong>Triggers</strong>: A worker job for a given branch.<br>
+        <strong>Triggered by</strong>: A change in dist-git (by polling).<br>
+        <strong>Controlled by</strong>: {platform-ci-project-link}. Do not edit this job via web UI.</p>
+
+    concurrent: false
+    node: '{team-slave}'
+    display-name: '{display-name}'
+    scm:
+        - git:
+            url: '{distgit-root-url}/{component}'
+            basedir: '{component}'
+            shallow-clone: true
+    triggers:
+        - pollscm: 'H/10 * * * *'
+    builders:
+        - shell: |
+            if [ ! -d platform-ci ]
+            then
+              git clone https://github.com/{github-user}/platform-ci.git platform-ci
+            fi
+            pushd platform-ci
+            git fetch origin
+            git checkout origin/{platform-ci-branch}
+            popd
+
+            export PATH="$PATH:platform-ci/build-on-push/scripts"
+            export PYTHONPATH="$PYTHONPATH:platform-ci/build-on-push/platform_ci"
+
+            job-commit-dispatcher.sh "{component}" "$GIT_BRANCH" "{github-user}" "{platform-ci-branch}"
+
+- job-template:
+    name: 'ci-{component}-dispatcher-commit'
+    defaults: 'ci-dispatcher-commit'
+
+# Parameters:
+#   * component: A name of a component for which this job is set up
+#   * team-slave: A slave on which this job should run
+#   * display-name: A human readable description of this job
+#   * git-branch: A dist-git branch of the component that this job will attempt to build
+#   * platform-ci-branch: A branch of Platform CI repo from which the support code is fetched
+
+#   * dispatcher-link: An <a> tag pair containing a link to the component's dispatcher job
+#   * platform-ci-project-link: An <a></a> tag pair with a link to the Platform CI project homepage
+#   * distgit-root-url: A URL to the DistGit root
+#   * github-user: A GitHub user whose fork of 'platform-ci' will be used by the generated jobs
+
+- defaults:
+    name: 'ci-workflow-brew-build'
+    description: |
+      <p>This job is triggered by a {dispatcher-link} job whenever branch <strong>{git-branch}</strong>
+      in dist-git repository for component <strong>{component}</strong> has new commits. This job then
+      issues a Brew scratch build from branch <strong>{git-branch}</strong> to test whether changed code
+      is buildable.</p>
+
+      <p>The build is issued via the following command:</p>
+
+      <p>$ rhpkg build --scratch --skip-nvr-check --target TARGET --arches x86_64</p>
+
+      <p><strong>Triggers:</strong> nothing<br>
+      <strong>Triggered by:</strong> {dispatcher-link}<br>
+      <strong>Controlled by:</strong> {platform-ci-project-link}. Do not edit this job via web UI.</p>
+    concurrent: true
+    node: '{team-slave}'
+    display-name: '{display-name}'
+    parameters:
+        - string:
+            name: BREW_TARGETS
+            default: ''
+            description: 'Space-separated list of brew targets'
+    scm:
+        - git:
+            url: '{distgit-root-url}/{component}'
+            branches:
+                - '{git-branch}'
+            basedir: '{component}'
+            local-branch: '{git-branch}'
+            shallow-clone: true
+    builders:
+        - shell: |
+            if [ ! -d platform-ci ]
+            then
+                git clone https://github.com/{github-user}/platform-ci.git platform-ci
+            fi
+            pushd platform-ci
+            git fetch origin
+            git checkout origin/{platform-ci-branch}
+            popd
+
+            export PATH="$PATH:platform-ci/build-on-push/scripts"
+            export PYTHONPATH="$PYTHONPATH:platform-ci/build-on-push/platform_ci"
+
+            job-commit-worker.sh "{component}" "{git-branch}"
+    publishers:
+        - archive:
+            artifacts: '*.log, *.txt'
+            allow-empty: 'true'
+        - email-ext:
+            recipients: '${{FILE,path="addresses.txt"}}'
+            reply-to: $DEFAULT_REPLYTO
+            content-type: default
+            subject: 'CI: $PROJECT_NAME #$BUILD_NUMBER ($BUILD_STATUS)'
+            body: ${{FILE,path="notification-email.txt"}}
+            attach-build-log: false
+            always: false
+            unstable: true
+            first-failure: true
+            not-built: true
+            aborted: true
+            regression: true
+            failure: true
+            improvement: true
+            still-failing: true
+            success: false
+            fixed: true
+            still-unstable: true
+            pre-build: false
+            matrix-trigger: only-configurations
+            send-to:
+                - requester
+                - recipients

--- a/build-on-push/jjb/platform-commit.yaml
+++ b/build-on-push/jjb/platform-commit.yaml
@@ -66,6 +66,8 @@
             export PYTHONPATH="$PYTHONPATH:platform-ci/build-on-push/platform_ci"
 
             job-commit-dispatcher.sh "{component}" "$GIT_BRANCH" "{github-user}" "{platform-ci-branch}"
+    wrappers:
+        - default-ci-workflow-wrappers
 
 - job-template:
     name: 'ci-{component}-dispatcher-commit'
@@ -129,6 +131,8 @@
             export PYTHONPATH="$PYTHONPATH:platform-ci/build-on-push/platform_ci"
 
             job-commit-worker.sh "{component}" "{git-branch}"
+    wrappers:
+        - default-ci-workflow-wrappers
     publishers:
         - archive:
             artifacts: '*.log, *.txt'

--- a/build-on-push/jjb/platform-component-setup.yaml
+++ b/build-on-push/jjb/platform-component-setup.yaml
@@ -1,0 +1,92 @@
+# Copyright 2016 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- defaults:
+    # Parameters:
+    #
+    #   * platform-ci-branch: A branch in 'platform-ci' repository used in generated jobs
+    #   * platform-ci-label: Human readable description on the branch in 'platform-ci' repository
+    #   * github-user: A GitHub user whose fork of 'platform-ci' will be used by the generated jobs
+ 
+    name: 'platform-component-setup'
+    display-name: 'Enable CI for a Platform component ({platform-ci-label})'
+    description: |
+        This job can be used to set up the template CI jobs for a Platform
+        component.
+
+        Managed by Jenkins Job Builder. Do not edit via web.
+    concurrent: true
+    node: 'jslave-baseos-build-on-commit'
+    scm:
+      - git:
+          url: 'https://github.com/{github-user}/platform-ci.git'
+          branches:
+            - origin/{platform-ci-branch}
+          basedir: 'platform-ci'
+    parameters:
+      - string:
+          name: COMPONENT
+          default: ''
+          description: 'A component name for which CI settings are altered'
+      - choice:
+          name: BUILD_ON_PUSH
+          choices:
+            - 'do not modify current settings'
+            - 'enable'
+            - 'disable'
+          description: |
+            Set ENABLE if automated builds on git commits pushed to dist-git should be enabled.
+            Set DISABLE if automated builds on git commits pushed to dist-git should be disabled.
+      - string:
+          name: SLAVE
+          default: ''
+          description: 'A name of the slave which will be used to run created jobs'
+    wrappers:
+        - default-ci-workflow-wrappers
+    builders:
+        - shell: |
+            export PATH="$PATH:platform-ci/build-on-push/scripts"
+            export PYTHONPATH="$PYTHONPATH:platform-ci/build-on-push/platform_ci"
+
+            job-platform-component-setup.sh "$COMPONENT" "$BUILD_ON_PUSH" "$SLAVE" "{github-user}" \
+              "{platform-ci-branch}"
+
+- job-template:
+    name: 'platform-component-setup-master'
+    defaults: 'platform-component-setup'
+
+- project:
+    name: platform-component-setup-master
+    project: platform-component-setup-master
+    jobs:
+      - platform-component-setup-master
+    platform-ci-branch: master
+    platform-ci-label: 'Production'
+    github-user: 'RHQE'
+
+# Template for testing instances of the component setup job
+# The job needs to have a different name that other component setup jobs
+
+#- job-template:
+#    name: 'platform-component-setup-testing'
+#    defaults: 'platform-component-setup'
+#
+#- project:
+#    name: platform-component-setup-testing
+#    project: platform-component-setup-testing
+#    jobs:
+#      - platform-component-setup-testing
+#    platform-ci-branch: boc-migration
+#    platform-ci-label: 'Testing'
+#    github-user: 'petr-muller'

--- a/build-on-push/jjb/platform-component-setup.yaml
+++ b/build-on-push/jjb/platform-component-setup.yaml
@@ -76,7 +76,7 @@
     github-user: 'RHQE'
 
 # Template for testing instances of the component setup job
-# The job needs to have a different name that other component setup jobs
+# The job needs to have a different name than other component setup jobs
 
 #- job-template:
 #    name: 'platform-component-setup-testing'

--- a/build-on-push/jjb/platform-defaults.yaml
+++ b/build-on-push/jjb/platform-defaults.yaml
@@ -1,0 +1,20 @@
+# Copyright 2016 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- wrapper:
+    name: default-ci-workflow-wrappers
+    wrappers:
+        - ansicolor
+        - workspace-cleanup
+        - timestamps

--- a/build-on-push/jjb/wscript
+++ b/build-on-push/jjb/wscript
@@ -1,0 +1,38 @@
+# Copyright 2016 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os.path
+import glob
+
+
+# pylint: disable=unused-argument
+def configure(ctx):
+    pass
+
+
+def build(ctx):
+    rebuild_jjb_tasks(ctx)
+
+
+def rebuild_templated_jjb_task(ctx, name, yaml_file):
+    ctx(rule="jenkins-jobs test -o jjb/ %s %s" % (ctx.path.abspath(), name),
+        source="platform-defaults.yaml %s.yaml" % yaml_file, target="%s" % name)
+
+
+def rebuild_jjb_tasks(ctx):
+    templated_jobs = [("platform-component-setup-master", "platform-component-setup")]
+
+    for job in templated_jobs:
+        rebuild_templated_jjb_task(ctx, job[0], job[1])
+

--- a/build-on-push/platform_ci/platform_ci/__init__.py
+++ b/build-on-push/platform_ci/platform_ci/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2016 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/build-on-push/platform_ci/platform_ci/brew.py
+++ b/build-on-push/platform_ci/platform_ci/brew.py
@@ -1,0 +1,213 @@
+# Copyright 2016 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module provides multiple classes representing Brew entities, mostly
+used to issue testing (scratch) builds and evaluating results of such
+requests.
+"""
+
+import os.path
+import logging
+import subprocess
+import tempfile
+import platform_ci.notifications as notifications
+
+
+class BuildToCommitterMapping(object):
+    """Provides a simple way to store committer addresses for CI-issued builds.
+
+    When CI issues Brew builds automatically, it does so under its own machine
+    credentials, not under credentials of the person who actually performed the
+    action that triggered the CI action (usually a git push). Therefore, Brew
+    tracks the CI machine account as a Brew build issuer, which may cause
+    later notifications (e.g. when such build is tested later) to be sent to
+    the machine account address instead of the right recipient.
+
+    This class allows to store committer information at the time when the build
+    is issued, mapping the issued build task ID to this committer information,
+    so it can be retrieved later.
+
+    Currently, the class stores the mapping in the filesystem, so it relies on
+    the later processing happening on the same Jenkins slave. This is fragile
+    and should be improved.
+    """
+    @staticmethod
+    def get_mapping_file_path(task_id):
+        """Return a filesystem path to a mapping file for a given Task ID."""
+        tempdir = tempfile.gettempdir()
+        task_id_filename = "platform-ci-{0}.mapping".format(task_id)
+        return os.path.join(tempdir, task_id_filename)
+
+    def __init__(self, task_id, committer):
+        self.task_id = task_id
+        self.committer = committer
+
+    def save(self):
+        """Save the mapping to the filesystem."""
+        with open(BuildToCommitterMapping.get_mapping_file_path(self.task_id), "w") as mapping_file:
+            mapping_file.write(self.committer)
+
+
+# pylint: disable=too-few-public-methods
+class BrewBuildAttemptException(notifications.PlatformCIException):
+    """Exception to be used on errors during Brew build attempts."""
+    header = notifications.create_platform_error_header(notifications.HEADERS["BREW_BUILD"])
+
+
+class BrewBuildAttempt(object):
+    """Represents an attempt to build current DistGit branch in Brew.
+
+    The build itself is issued using the 'rhpkg' command.
+    """
+    def __init__(self, target, logdir):
+        self.target = target
+        self._execution = None
+        self.logfile_path = os.path.join(logdir, "build-%s.log" % self.target)
+        self._logfile = None
+        self._success = None
+
+    def execute(self):
+        """Issue the request to build a scratch build in Brew.
+
+        The method returns immediately after the request is issued, it does not
+        wait until the request is finished.
+
+        The current working directory needs to contain a checked-out DistGit
+        branch.
+        """
+        logging.info("Building for target [%s]", self.target)
+        self._logfile = open(self.logfile_path, "w")
+        self._execution = subprocess.Popen(["rhpkg", "build", "--scratch", "--skip-nvr-check", "--target", self.target,
+                                            "--arches", "x86_64"], stdout=self._logfile, stderr=self._logfile)
+
+    def wait(self):
+        """Blocks until the build request is finished.
+
+        After this methods returns, the result is available to be picked up
+        by the passed() method and the logs are created.
+        """
+        self._execution.wait()
+        if self._execution.returncode == 0:
+            logging.info("Brew build for target [%s] was successful", self.target)
+            self._success = True
+        else:
+            logging.error("Brew build for target [%s] failed", self.target)
+            self._success = False
+        self._logfile.close()
+
+    def passed(self):
+        """Returns True if the build request was successful, False otherwise.
+
+        Can be only called after a previous wait() method call.
+        Raises:
+            BrewBuildAttemptException: When called without previous wait() method
+                call.
+        """
+        if self._success is None:
+            raise BrewBuildAttemptException("Brew build success was not set in wait() method")
+
+        return self._success
+
+    @property
+    def short_result(self):
+        """Returns "PASS" if build request was successful, "FAIL" otherwise.
+
+        Can be only called after a previous wait() method call.
+
+        Raises:
+            BrewBuildAttemptException: When called without previous wait() method
+                call.
+        """
+        if self.passed():
+            return "PASS"
+        else:
+            return "FAIL"
+
+    @property
+    def url(self):
+        """Returns a URL to the Brew task of an issued task.
+
+        Can be only called after a previous wait() method call.
+        """
+        with open(self.logfile_path, "r") as logfile:
+            for line in logfile:
+                if line.startswith("Task info: "):
+                    return line[11:].strip()
+        return None
+
+    @property
+    def task_id(self):
+        """Returns a Task ID of an issued task.
+
+        Can be only called after a previous wait() method call.
+        """
+        with open(self.logfile_path, "r") as logfile:
+            for line in logfile:
+                if line.startswith("Created task: "):
+                    return line[14:].strip()
+        return None
+
+
+class BrewBuildAttempts(object):
+    """Represents multiple simultaneous build attempts."""
+
+    def __init__(self, targets, logdir):
+        self.targets = targets
+        self.logdir = logdir
+        self.builds = {}
+
+    def all(self):
+        """Returns a list of all build requests."""
+        return self.builds.values()
+
+    def execute(self):
+        """Issue all build requests.
+
+        The method returns immediately after all requests are issued, it does
+        not wait until any request is finished.
+        """
+        for target in self.targets:
+            self.builds[target] = BrewBuildAttempt(target, self.logdir)
+            self.builds[target].execute()
+
+    def wait(self):
+        """Block until all issued build requests finish.
+
+        After this methods returns, the results are available to be collected.
+        """
+        for target in self.targets:
+            self.builds[target].wait()
+
+    def all_successful(self):
+        """Returns all successful build requests.
+
+        Can be only called after a previous wait() method call.
+        """
+        for target in self.targets:
+            if not self.builds[target].passed():
+                return False
+
+        return True
+
+    def count_failed(self):
+        """Returns how many build attempts were not successful.
+
+        Can be only called after a previous wait() method call.
+        """
+        failed = 0
+        for target in self.builds:
+            if not self.builds[target].passed():
+                failed += 1
+        return failed

--- a/build-on-push/platform_ci/platform_ci/brew_test.py
+++ b/build-on-push/platform_ci/platform_ci/brew_test.py
@@ -1,0 +1,128 @@
+# Copyright 2016 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from sys import version_info
+import unittest
+import os.path
+from mock import patch, Mock
+# pylint: disable=no-name-in-module
+from nose.tools import assert_raises
+
+from .brew import BrewBuildAttempt, BrewBuildAttempts, BrewBuildAttemptException
+
+# pylint: disable=no-member
+try:
+    major = version_info.major
+except AttributeError:
+    major = version_info[0]
+
+# pylint: disable=import-error,wrong-import-order,wrong-import-position
+if major == 2:
+    import __builtin__ as builtins
+else:
+    import builtins
+
+
+class BrewBuildAttemptTest(unittest.TestCase):
+    TEST_TESTDIR = "/a/directory"
+    TEST_TARGET = "rhel-6.88-candidate"
+
+    def setUp(self):
+        self.bba = BrewBuildAttempt(BrewBuildAttemptTest.TEST_TARGET, BrewBuildAttemptTest.TEST_TESTDIR)
+
+    def sanity_test(self):
+        assert self.bba.target == BrewBuildAttemptTest.TEST_TARGET
+        assert self.bba.logfile_path == os.path.join(BrewBuildAttemptTest.TEST_TESTDIR, "build-rhel-6.88-candidate.log")
+        assert_raises(BrewBuildAttemptException, self.bba.passed)
+
+    @patch.object(builtins, 'open')
+    @patch('subprocess.Popen')
+    def execute_test(self, mock_popen, mock_open):
+        self.bba.execute()
+        assert mock_open.called
+        assert mock_open.call_args[0][0] == self.bba.logfile_path
+        assert mock_popen.called
+        assert mock_popen.call_args[0][0] == ["rhpkg", "build", "--scratch", "--skip-nvr-check", "--target",
+                                              BrewBuildAttemptTest.TEST_TARGET, "--arches", "x86_64"]
+
+    # pylint: disable=protected-access
+    def wait_success_test(self):
+        self.bba._execution = Mock()
+        self.bba._execution.wait = Mock()
+        self.bba._execution.returncode = 0
+        self.bba._logfile = Mock()
+        self.bba._logfile.close = Mock()
+
+        self.bba.wait()
+        assert self.bba._execution.wait.called
+        assert self.bba._logfile.close.called
+        assert self.bba.passed()
+
+    # pylint: disable=protected-access
+    def wait_failure_test(self):
+        self.bba._execution = Mock()
+        self.bba._execution.wait = Mock()
+        self.bba._execution.returncode = 1
+        self.bba._logfile = Mock()
+        self.bba._logfile.close = Mock()
+
+        self.bba.wait()
+        assert self.bba._execution.wait.called
+        assert self.bba._logfile.close.called
+        assert not self.bba.passed()
+
+
+class BrewBuildAttemptsTest(unittest.TestCase):
+    TEST_TARGETS = ("target-1-test", "target-2-test")
+    TEST_LOGDIR = "/a/logdir"
+
+    def setUp(self):
+        self.bba = BrewBuildAttempts(BrewBuildAttemptsTest.TEST_TARGETS, BrewBuildAttemptsTest.TEST_LOGDIR)
+
+    def sanity_test(self):
+        assert self.bba.targets == BrewBuildAttemptsTest.TEST_TARGETS
+        assert self.bba.logdir == BrewBuildAttemptsTest.TEST_LOGDIR
+        assert self.bba.builds == {}
+
+    @patch('platform_ci.brew.BrewBuildAttempt')
+    def execute_test(self, mock_bba):
+        mock_bba.return_value = Mock()
+        mock_bba.return_value.execute = Mock()
+        self.bba.execute()
+        assert mock_bba.called
+        assert mock_bba.call_count == 2
+        assert len(self.bba.builds) == 2
+
+        for target in BrewBuildAttemptsTest.TEST_TARGETS:
+            assert self.bba.builds[target].execute.called
+
+    def wait_test(self):
+        for target in BrewBuildAttemptsTest.TEST_TARGETS:
+            self.bba.builds[target] = Mock()
+            self.bba.builds[target].wait = Mock()
+
+        self.bba.wait()
+
+        for target in BrewBuildAttemptsTest.TEST_TARGETS:
+            assert self.bba.builds[target].wait.called
+
+    def all_successful_test(self):
+        for target in BrewBuildAttemptsTest.TEST_TARGETS:
+            self.bba.builds[target] = Mock()
+            self.bba.builds[target].passed = Mock()
+            self.bba.builds[target].passed.return_value = True
+        assert self.bba.all_successful()
+
+        self.bba.builds[BrewBuildAttemptsTest.TEST_TARGETS[0]].passed.return_value = False
+        assert not self.bba.all_successful()

--- a/build-on-push/platform_ci/platform_ci/ci_types.py
+++ b/build-on-push/platform_ci/platform_ci/ci_types.py
@@ -21,8 +21,8 @@ represent such CI functionality: they understand which jobs are needed,
 how to create or disable them and how to run their individual parts.
 """
 
-import yaml
 import logging
+import yaml
 from .jenkins_jobs import JobCommitDispatcher, JobBuildOnCommit
 
 

--- a/build-on-push/platform_ci/platform_ci/ci_types.py
+++ b/build-on-push/platform_ci/platform_ci/ci_types.py
@@ -219,7 +219,7 @@ class CommitCI(PlatformCI):
         self._run_on_targets(branch.name, config.targets, slave, platform_ci_source)
         return config.targets
 
-    def consider_build(self, commit, slave, platform_ci_source, config):
+    def consider_build(self, commit, slave, platform_ci_source, config_file):
         """Trigger a worker job for a branch, depending on the branch type.
 
         Trigger a worker job either if branch is a staging branch or a private
@@ -232,17 +232,17 @@ class CommitCI(PlatformCI):
             slave: A slave name on which the worker job should be executed
             platform_ci_source: A PlatformCISource instance describing the repo
                 from which the code will be fetched inside the worker job.
-            config_file: A path to a config file inside a dist-git branch.
+            config_file: A path to a config file inside a dist-git branch, or None
         """
 
         branch = commit.branch
 
         if branch.is_staging():
             logging.info("Branch [%s] should be built: it is a staging branch", branch.name)
-            built_targets = self._run_on_staging(branch, slave, platform_ci_source, config)
-        elif config is not None:
+            built_targets = self._run_on_staging(branch, slave, platform_ci_source, config_file)
+        elif config_file is not None:
             logging.info("Branch [%s] should be built: it contains a 'ci.yaml' file", branch.name)
-            built_targets = self._run_by_config(branch, slave, platform_ci_source, config)
+            built_targets = self._run_by_config(branch, slave, platform_ci_source, config_file)
         else:
             logging.warning("Branch [%s] is not a staging branch and 'ci.yaml' file was not found", branch.name)
             logging.warning("Branch [%s] should not be built", branch.name)

--- a/build-on-push/platform_ci/platform_ci/ci_types.py
+++ b/build-on-push/platform_ci/platform_ci/ci_types.py
@@ -1,0 +1,238 @@
+# Copyright 2016 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This module implements the "CI for Component" concept.
+
+A "CI for Component" is a high-level concept: if a certain CI functionality
+is enabled for a component, it means a certain set of Jenkins jobs need
+to be present and enabled on a Jenkins instance. The classes in this module
+represent such CI functionality: they understand which jobs are needed,
+how to create or disable them and how to run their individual parts.
+"""
+
+import yaml
+import logging
+from .jenkins_jobs import JobCommitDispatcher, JobBuildOnCommit
+
+
+# pylint: disable=too-few-public-methods
+class PlatformCI(object):
+    """Base class for further extension.
+
+    Provides basic job operations over a Jenkins instance.
+    """
+    def __init__(self, jenkins, component):
+        self.component = component
+        self.jenkins = jenkins
+
+    def _delete_job(self, job):
+        """Deletes a job from Jenkins.
+
+        Does nothing if the job does not exist.
+        """
+        if self.jenkins.job_exists(job):
+            self.jenkins.delete_job(job)
+
+    def _enable_job(self, job):
+        """Enables a job on Jenkins.
+
+        If the job does not exist, it is created. If the job exists, it is
+        updated using the current JJB templates.
+        """
+        if self.jenkins.job_exists(job):
+            self.jenkins.update_job(job)
+            self.jenkins.enable_job(job)
+        else:
+            self.jenkins.create_job(job)
+
+    def _disable_job(self, job):
+        """Disables job on Jenkins.
+
+        Does nothing if the job does not exist.
+        """
+        if self.jenkins.job_exists(job):
+            self.jenkins.disable_job(job)
+
+
+# pylint: disable=too-few-public-methods
+class CommitCIConfig(object):
+    """Small class representing the ci.yaml control file.
+
+    Developers can include a ci.yaml control file in their repository branches
+    to indicate such branch should be automatically built and tested (similar
+    to how Travis CI works).
+    """
+    def __init__(self, ci_file_path):
+        with open(ci_file_path, 'r') as ci_file:
+            ci_config = yaml.load(ci_file)
+            self.targets = ci_config["auto-build"]["targets"]
+
+
+class CommitCI(PlatformCI):
+    """Implements the Build-on-Push CI functionality.
+
+    The Build-on-Push is a universal CI mechanism allowing automated issue
+    of testing (scratch) builds whenever there are new commits in a given
+    DistGit branch pushed to a central, monitored location.
+
+    Currently there are two mechanisms which decide which branches of a DistGit
+    repository should be built: first, it's a *staging branch* concept which
+    recognizes the importance of a branch from the branch name. Second, the
+    developers can put a simple YAML config file to a branch, indicating
+    such branch should be also automatically built.
+
+    Build-on-Push CI consists of two types of jobs: a single *dispatcher* job
+    monitors events in the whole repository, and whenever there are any new
+    commits in any branch, it decides if the branch should be automatically
+    built. If yes, it triggers a *worker* job for a given branch: there is
+    a single *worker* job per DistGit branch, and its only job is to issue
+    a scratch build request to Brew.
+    """
+    def __init__(self, jenkins, component):
+        super(CommitCI, self).__init__(jenkins, component)
+
+    def enable(self, slave, platform_ci_repo, platform_ci_branch):
+        """Enable Build-on-Push for a component.
+
+        Implementation-wise, create or enable a dispatcher job for a given
+        component.
+
+        Args:
+            slave: A name of a Jenkins slave that will run the created jobs
+            platform_ci_branch: A branch of the Platform CI repository that
+                will be used as a source of support code in creaetd jobs.
+        """
+        dispatcher = JobCommitDispatcher(self.component, slave, platform_ci_repo, platform_ci_branch)
+
+        self._enable_job(dispatcher)
+
+    def disable(self):
+        """Disable Build-on-Push for a component."""
+        dispatcher = JobCommitDispatcher(self.component)
+
+        self._disable_job(dispatcher)
+
+    def _run_on_targets(self, branch, targets, slave, platform_ci_repo, platform_ci_branch):
+        """Trigger a worker job building a dist-git branch in several targets.
+
+        There is a single worker job per dist-git branch. If a worker job
+        does not exist, is disabled or has different configuration the method
+        creates/enables/reconfigures it.
+
+        Args:
+            branch: A dist-git branch name
+            targets: A sequence of Brew target names
+            slave: A slave name on which the worker job should be executed
+            platform_ci_repo: A GitHub account whose fork of Platform CI will
+                be fetched inside the worker job.
+            platform_ci_branch: A branch from the platform-ci repo from which
+                the code will be fetched inside the worker job.
+        """
+
+        worker = JobBuildOnCommit(self.component, branch, slave, platform_ci_repo, platform_ci_branch)
+        self._enable_job(worker)
+        self.jenkins.trigger_job(worker, parameters={"BREW_TARGETS": " ".join(targets)})
+
+    def _run_on_staging(self, staging_branch, slave, platform_ci_repo, platform_ci_branch, config_file=None):
+        """Trigger a worker job building a staging branch in its associated Brew target.
+
+        There is a single worker job per dist-git branch. If a worker job
+        does not exist, is disabled or has different configuration the method
+        creates/enables/reconfigures it. A staging branch has a single associated
+        Brew target: this target is always built. Additionally, any target specified
+        in the ci.yaml file (if present) is built too.
+
+        Args:
+            staging_branch: A DistGitBranch instance representing a branch. It must
+                have a 'staging' or 'private staging' type.
+            slave: A slave name on which the worker job should be executed
+            platform_ci_branch: A branch from the platform-ci repo from which
+                the code will be fetched inside the worker job.
+            config_file: A path to a config file inside a dist-git branch.
+
+        Returns:
+            A list of target names that will be built in the triggered job.
+
+        Raises:
+            distgit.DistGutBranchException: Passed staging_branch is not a staging branch.
+        """
+
+        if config_file is not None:
+            logging.info("Config file is present in the branch: %s", config_file)
+            config = CommitCIConfig(config_file)
+            targets = list(config.targets)
+            logging.info("Targets from config file: %s", str(targets))
+        else:
+            logging.info("Config file is not present in the branch: no targets aside of staging target will be tested")
+            targets = []
+
+        staging_target = staging_branch.staging_target
+        logging.info("Staging target: %s", staging_target)
+
+        if staging_target not in targets:
+            targets.append(staging_target)
+
+        self._run_on_targets(staging_branch.name, targets, slave, platform_ci_repo, platform_ci_branch)
+        return targets
+
+    def _run_by_config(self, branch, slave, platform_ci_repo, platform_ci_branch, config_file):
+        """Trigger a worker job building a branch in targets specified in a config file.
+
+        There is a single worker job per dist-git branch. If a worker job
+        does not exist, is disabled or has different configuration the method
+        creates/enables/reconfigures it.
+
+        Args:
+            branch: A DistGitBranch instance representing a branch
+            slave: A slave name on which the worker job should be executed
+            platform_ci_branch: A branch from the platform-ci repo from which
+                the code will be fetched inside the worker job.
+            config_file: A path to a config file inside a dist-git branch.
+
+        Returns:
+            A list of target names that will be built in the triggered job.
+        """
+        config = CommitCIConfig(config_file)
+        logging.info("Targets from config file: %s", config.targets)
+        self._run_on_targets(branch.name, config.targets, slave, platform_ci_repo, platform_ci_branch)
+        return config.targets
+
+    def consider_build(self, branch, slave, platform_ci_repo, platform_ci_branch, config):
+        """Trigger a worker job for a branch, depending on the branch type.
+
+        Trigger a worker job either if branch is a staging branch or a private
+        staging branch, or if there is a CI config file present in a branch. Do
+        not trigger a worker job otherwise. If a job is triggered and this method
+        is run inside a Jenkins job build, set a description of that build.
+
+        Args:
+            branch: A DistGitBranch representing a branch
+            slave: A slave name on which the worker job should be executed
+            platform_ci_branch: A branch from the platform-ci repo from which
+                the code will be fetched inside the worker job.
+            config_file: A path to a config file inside a dist-git branch.
+        """
+        if branch.is_staging():
+            logging.info("Branch [%s] should be built: it is a staging branch", branch.name)
+            built_targets = self._run_on_staging(branch, slave, platform_ci_repo, platform_ci_branch, config)
+        elif config is not None:
+            logging.info("Branch [%s] should be built: it contains a 'ci.yaml' file", branch.name)
+            built_targets = self._run_by_config(branch, slave, platform_ci_repo, platform_ci_branch, config)
+        else:
+            logging.warning("Branch [%s] is not a staging branch and 'ci.yaml' file was not found", branch.name)
+            logging.warning("Branch [%s] should not be built", branch.name)
+            built_targets = []
+
+        description = JobCommitDispatcher.create_description(branch, built_targets, self.jenkins.url, self.component)
+        self.jenkins.set_current_build_description(description)

--- a/build-on-push/platform_ci/platform_ci/commit_ci_test.py
+++ b/build-on-push/platform_ci/platform_ci/commit_ci_test.py
@@ -19,7 +19,7 @@ from mock import MagicMock, patch
 from nose.tools import assert_raises
 
 from platform_ci.distgit import DistGitBranch, DistGitBranchException
-from platform_ci.ci_types import CommitCI, CommitCIConfig
+from platform_ci.ci_types import CommitCI, CommitCIConfig, PlatformCISource
 
 
 # pylint: disable=no-member,wrong-import-position,wrong-import-order
@@ -63,6 +63,7 @@ class CommitCITest(unittest.TestCase):
     TEST_SLAVE = "team-slave"
     TEST_PLATFORM_CI_BRANCH = "test-branch"
     TEST_GITHUB_USER = "RHQE"
+    TEST_PLATFORM_CODE_SOURCE = PlatformCISource(TEST_GITHUB_USER, TEST_PLATFORM_CI_BRANCH)
 
     def setUp(self):
         self.jenkins = MagicMock()
@@ -70,15 +71,13 @@ class CommitCITest(unittest.TestCase):
 
     def test_enable_when_not_exists(self):
         self.jenkins.job_exists.return_value = False
-        self.commitci.enable(CommitCITest.TEST_SLAVE, CommitCITest.TEST_PLATFORM_CI_BRANCH,
-                             CommitCITest.TEST_GITHUB_USER)
+        self.commitci.enable(CommitCITest.TEST_SLAVE, CommitCITest.TEST_PLATFORM_CODE_SOURCE)
         assert self.jenkins.job_exists.called
         assert self.jenkins.create_job.called
 
     def test_enable_when_exists(self):
         self.jenkins.job_exists.return_value = True
-        self.commitci.enable(CommitCITest.TEST_SLAVE, CommitCITest.TEST_PLATFORM_CI_BRANCH,
-                             CommitCITest.TEST_GITHUB_USER)
+        self.commitci.enable(CommitCITest.TEST_SLAVE, CommitCITest.TEST_PLATFORM_CODE_SOURCE)
         assert self.jenkins.job_exists.called
         assert not self.jenkins.create_job.called
         assert self.jenkins.update_job.called
@@ -87,8 +86,7 @@ class CommitCITest(unittest.TestCase):
     # pylint: disable=protected-access
     def test_enable(self):
         self.commitci._enable_job = MagicMock()
-        self.commitci.enable(CommitCITest.TEST_SLAVE, CommitCITest.TEST_PLATFORM_CI_BRANCH,
-                             CommitCITest.TEST_GITHUB_USER)
+        self.commitci.enable(CommitCITest.TEST_SLAVE, CommitCITest.TEST_PLATFORM_CODE_SOURCE)
 
         assert self.commitci._enable_job.called
         job = self.commitci._enable_job.call_args[0][0]
@@ -101,8 +99,7 @@ class CommitCITest(unittest.TestCase):
         self.commitci._run_on_targets = MagicMock()
 
         self.commitci._run_by_config(DistGitBranch(CommitCITest.TEST_BRANCH), CommitCITest.TEST_SLAVE,
-                                     CommitCITest.TEST_GITHUB_USER, CommitCITest.TEST_PLATFORM_CI_BRANCH,
-                                     CommitCITest.TEST_CONFIG_FILE)
+                                     CommitCITest.TEST_PLATFORM_CODE_SOURCE, CommitCITest.TEST_CONFIG_FILE)
         assert self.commitci._run_on_targets.called
         assert self.commitci._run_on_targets.call_args[0][0] == CommitCITest.TEST_BRANCH
         assert self.commitci._run_on_targets.call_args[0][1] == CommitCITest.TEST_TARGETS
@@ -111,8 +108,7 @@ class CommitCITest(unittest.TestCase):
         self.commitci._run_on_targets = MagicMock()
         staging = DistGitBranch(CommitCITest.TEST_STAGING_BRANCH)
 
-        self.commitci._run_on_staging(staging, CommitCITest.TEST_SLAVE, CommitCITest.TEST_GITHUB_USER,
-                                      CommitCITest.TEST_PLATFORM_CI_BRANCH)
+        self.commitci._run_on_staging(staging, CommitCITest.TEST_SLAVE, CommitCITest.TEST_PLATFORM_CODE_SOURCE)
         assert self.commitci._run_on_targets.called
         assert self.commitci._run_on_targets.call_args[0][0] == CommitCITest.TEST_STAGING_BRANCH
         assert self.commitci._run_on_targets.call_args[0][1] == [CommitCITest.TEST_STAGING_TARGET]
@@ -124,8 +120,8 @@ class CommitCITest(unittest.TestCase):
         staging = DistGitBranch(CommitCITest.TEST_STAGING_BRANCH)
         self.commitci._run_on_targets = MagicMock()
 
-        self.commitci._run_on_staging(staging, CommitCITest.TEST_SLAVE, CommitCITest.TEST_GITHUB_USER,
-                                      CommitCITest.TEST_PLATFORM_CI_BRANCH, CommitCITest.TEST_CONFIG_FILE)
+        self.commitci._run_on_staging(staging, CommitCITest.TEST_SLAVE, CommitCITest.TEST_PLATFORM_CODE_SOURCE,
+                                      CommitCITest.TEST_CONFIG_FILE)
 
         assert self.commitci._run_on_targets.called
         assert self.commitci._run_on_targets.call_args[0][0] == CommitCITest.TEST_STAGING_BRANCH
@@ -135,4 +131,4 @@ class CommitCITest(unittest.TestCase):
     def test_run_on_staging_invalid(self):
         staging = DistGitBranch(CommitCITest.TEST_BRANCH)
         assert_raises(DistGitBranchException, self.commitci._run_on_staging, staging, CommitCITest.TEST_SLAVE,
-                      CommitCITest.TEST_GITHUB_USER, CommitCITest.TEST_PLATFORM_CI_BRANCH)
+                      CommitCITest.TEST_PLATFORM_CODE_SOURCE)

--- a/build-on-push/platform_ci/platform_ci/commit_ci_test.py
+++ b/build-on-push/platform_ci/platform_ci/commit_ci_test.py
@@ -1,0 +1,138 @@
+# Copyright 2016 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from sys import version_info
+import unittest
+from mock import MagicMock, patch
+# pylint: disable=no-name-in-module
+from nose.tools import assert_raises
+
+from platform_ci.distgit import DistGitBranch, DistGitBranchException
+from platform_ci.ci_types import CommitCI, CommitCIConfig
+
+
+# pylint: disable=no-member,wrong-import-position,wrong-import-order
+try:
+    major = version_info.major
+except AttributeError:
+    major = version_info[0]
+
+# pylint: disable=import-error
+if major == 2:
+    import __builtin__ as builtins
+else:
+    import builtins
+
+
+# pylint: disable=too-many-public-methods
+class CommitCIConfigTest(unittest.TestCase):
+
+    TEST_TARGET = "rhel-7.1-candidate"
+
+    # pylint: disable=no-self-use
+    @patch('yaml.load')
+    @patch.object(builtins, 'open')
+    def test_sanity(self, mock_open, mock_yaml_load):
+        mock_yaml_load.return_value = {"auto-build": {"targets": [CommitCIConfigTest.TEST_TARGET]}}
+        config = CommitCIConfig("some_path")
+        assert mock_open.called
+        assert mock_yaml_load.called
+        assert config.targets == [CommitCIConfigTest.TEST_TARGET]
+
+
+# pylint: disable=too-many-public-methods
+class CommitCITest(unittest.TestCase):
+
+    TEST_COMPONENT = "test-component"
+    TEST_TARGETS = ["test-1-target", "test-2-target"]
+    TEST_BRANCH = "test-branch"
+    TEST_CONFIG_FILE = "/file/to/path"
+    TEST_STAGING_BRANCH = "rhel-6.7-staging"
+    TEST_STAGING_TARGET = "rhel-6.7-candidate"
+    TEST_SLAVE = "team-slave"
+    TEST_PLATFORM_CI_BRANCH = "test-branch"
+    TEST_GITHUB_USER = "RHQE"
+
+    def setUp(self):
+        self.jenkins = MagicMock()
+        self.commitci = CommitCI(self.jenkins, CommitCITest.TEST_COMPONENT)
+
+    def test_enable_when_not_exists(self):
+        self.jenkins.job_exists.return_value = False
+        self.commitci.enable(CommitCITest.TEST_SLAVE, CommitCITest.TEST_PLATFORM_CI_BRANCH,
+                             CommitCITest.TEST_GITHUB_USER)
+        assert self.jenkins.job_exists.called
+        assert self.jenkins.create_job.called
+
+    def test_enable_when_exists(self):
+        self.jenkins.job_exists.return_value = True
+        self.commitci.enable(CommitCITest.TEST_SLAVE, CommitCITest.TEST_PLATFORM_CI_BRANCH,
+                             CommitCITest.TEST_GITHUB_USER)
+        assert self.jenkins.job_exists.called
+        assert not self.jenkins.create_job.called
+        assert self.jenkins.update_job.called
+        assert self.jenkins.enable_job.called
+
+    # pylint: disable=protected-access
+    def test_enable(self):
+        self.commitci._enable_job = MagicMock()
+        self.commitci.enable(CommitCITest.TEST_SLAVE, CommitCITest.TEST_PLATFORM_CI_BRANCH,
+                             CommitCITest.TEST_GITHUB_USER)
+
+        assert self.commitci._enable_job.called
+        job = self.commitci._enable_job.call_args[0][0]
+        assert job.component == CommitCITest.TEST_COMPONENT
+
+    @patch('platform_ci.ci_types.CommitCIConfig')
+    def test_run_by_config(self, mock_commitconfig):
+        mock_commitconfig.return_value = MagicMock()
+        mock_commitconfig.return_value.targets = CommitCITest.TEST_TARGETS
+        self.commitci._run_on_targets = MagicMock()
+
+        self.commitci._run_by_config(DistGitBranch(CommitCITest.TEST_BRANCH), CommitCITest.TEST_SLAVE,
+                                     CommitCITest.TEST_GITHUB_USER, CommitCITest.TEST_PLATFORM_CI_BRANCH,
+                                     CommitCITest.TEST_CONFIG_FILE)
+        assert self.commitci._run_on_targets.called
+        assert self.commitci._run_on_targets.call_args[0][0] == CommitCITest.TEST_BRANCH
+        assert self.commitci._run_on_targets.call_args[0][1] == CommitCITest.TEST_TARGETS
+
+    def test_run_on_staging(self):
+        self.commitci._run_on_targets = MagicMock()
+        staging = DistGitBranch(CommitCITest.TEST_STAGING_BRANCH)
+
+        self.commitci._run_on_staging(staging, CommitCITest.TEST_SLAVE, CommitCITest.TEST_GITHUB_USER,
+                                      CommitCITest.TEST_PLATFORM_CI_BRANCH)
+        assert self.commitci._run_on_targets.called
+        assert self.commitci._run_on_targets.call_args[0][0] == CommitCITest.TEST_STAGING_BRANCH
+        assert self.commitci._run_on_targets.call_args[0][1] == [CommitCITest.TEST_STAGING_TARGET]
+
+    @patch('platform_ci.ci_types.CommitCIConfig')
+    def test_run_on_staging_with_config(self, mock_commitconfig):
+        mock_commitconfig.return_value = MagicMock()
+        mock_commitconfig.return_value.targets = CommitCITest.TEST_TARGETS
+        staging = DistGitBranch(CommitCITest.TEST_STAGING_BRANCH)
+        self.commitci._run_on_targets = MagicMock()
+
+        self.commitci._run_on_staging(staging, CommitCITest.TEST_SLAVE, CommitCITest.TEST_GITHUB_USER,
+                                      CommitCITest.TEST_PLATFORM_CI_BRANCH, CommitCITest.TEST_CONFIG_FILE)
+
+        assert self.commitci._run_on_targets.called
+        assert self.commitci._run_on_targets.call_args[0][0] == CommitCITest.TEST_STAGING_BRANCH
+        expected_targets = CommitCITest.TEST_TARGETS + [CommitCITest.TEST_STAGING_TARGET]
+        assert self.commitci._run_on_targets.call_args[0][1] == expected_targets
+
+    def test_run_on_staging_invalid(self):
+        staging = DistGitBranch(CommitCITest.TEST_BRANCH)
+        assert_raises(DistGitBranchException, self.commitci._run_on_staging, staging, CommitCITest.TEST_SLAVE,
+                      CommitCITest.TEST_GITHUB_USER, CommitCITest.TEST_PLATFORM_CI_BRANCH)

--- a/build-on-push/platform_ci/platform_ci/config.py
+++ b/build-on-push/platform_ci/platform_ci/config.py
@@ -1,0 +1,34 @@
+import os
+
+
+class PlatformCIConfig(object):
+    def __init__(self):
+        pass
+
+    @property
+    def project_url(self):
+        return os.environ.get("PLATFORM_CI_PROJECT", None)
+
+    @property
+    def distgit_url(self):
+        return os.environ.get("BOP_DIST_GIT_URL", None)
+
+    @property
+    def jenkins_url(self):
+        return os.environ.get("JENKINS_URL", None)
+
+    @property
+    def staging_branch_doc_url(self):
+        return os.environ.get("BOP_STAGING_BRANCH_DOC", None)
+
+    @property
+    def admins(self):
+        return os.environ.get("PLATFORM_CI_ADMINS", None)
+
+    @property
+    def bug_destination(self):
+        return os.environ.get("PLATFORM_CI_BUG_DESTINATION")
+
+    @property
+    def jenkins_cli_path(self):
+        return os.environ.get("BOP_JENKINS_CLI", None)

--- a/build-on-push/platform_ci/platform_ci/distgit.py
+++ b/build-on-push/platform_ci/platform_ci/distgit.py
@@ -1,0 +1,108 @@
+# Copyright 2016 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import platform_ci.notifications as notifications
+
+
+class DistGitBranchException(notifications.PlatformCIException):
+    """Thrown on errors encountered during work with DistGit branches."""
+    header = notifications.create_platform_error_header(notifications.HEADERS["DIST_GIT"])
+
+
+class DistGitBranch(object):
+    """The class represents a DistGit branch.
+
+    The class does not actually interface with DistGit: all methods are
+    performed only over the *names* of the branches. There is no dependency
+    on actually having access to DistGit or any clone.
+    """
+
+    # Standard branch examples: rhel-7.3, extras-rhel-7.2
+    STANDARD_BRANCH_REGEXP_PATTERN = r'(?P<st_branch>((extras-)|(rhscl-\d\.\d-rh-\w+?-))?rhel-\d(\.\d)?)$'
+
+    # Staging branch examples:
+    #   - Proper staging branches: rhel-7.3-staging, extras-rhel-7.2-staging
+    #   - Private staging branches: private-pmuller-rhel-7.3-staging-bz1234567
+    #                               private-pmuller-extras-rhel-7.2-staging
+    STAGING_BRANCH_REGEXP_PATTERN = r'(?P<st_branch>((extras-)|(rhscl-\d\.\d-rh-\w+?-))?rhel-\d(\.\d)?-staging)'
+
+    STANDARD_BRANCH_REGEXP = re.compile(STANDARD_BRANCH_REGEXP_PATTERN)
+
+    # Note: The branch can be suffixed only if it is private staging branch - has special prefix
+    STAGING_BRANCH_REGEXP = re.compile(r'(?P<prefix>private-[\w_-]*?)?' + STAGING_BRANCH_REGEXP_PATTERN +
+                                       r'(?(prefix)[\w_-]*?|$)')
+
+    def __init__(self, branch):
+        self.name = branch
+
+    def is_staging(self):
+        return DistGitBranch.STAGING_BRANCH_REGEXP.match(self.name) is not None
+
+    def is_standard(self):
+        return DistGitBranch.STANDARD_BRANCH_REGEXP.match(self.name) is not None
+
+    @property
+    def staging_target(self):
+        """Computes a Brew target name matching the branch
+
+        Returns: A name of the Brew target associated with the branch name
+
+        Example: DistGitBranch("rhel-7.3-staging").staging_target -> "rhel-7.3-candidate"
+        """
+        if self.is_staging():
+            # Use just the staging branch name match
+            staging_branch_base = DistGitBranch.STAGING_BRANCH_REGEXP.match(self.name).group('st_branch')
+
+            # TODO: if the staging branch will be e.g. "rhel-6-staging", the target would be determined incorrectly
+            # We would have to get the latest RHEL-6 target and use that.
+            return staging_branch_base.replace("staging", "candidate")
+        elif self.is_standard():
+            # Use just the staging branch name match
+            standard_branch_base = DistGitBranch.STANDARD_BRANCH_REGEXP.match(self.name).group('st_branch')
+
+            # TODO: if the staging branch will be e.g. "rhel-6-staging", the target would be determined incorrectly
+            # We would have to get the latest RHEL-6 target and use that.
+            return standard_branch_base + "-candidate"
+
+        raise DistGitBranchException("%s is not a staging or standard branch" % self.name)
+
+    @property
+    def type(self):
+        """Returns a type of the branch.
+
+        There are four branch types: official, staging, private, and private staging.
+        The type is determined from the branch name. A staging branch is named as a
+        standard branch with '-staging' suffix. A private staging branch is a well-named
+        private branch (with private- prefix) containing a name of a staging branch inside.
+        Any other name is considered to be private branch.
+
+        Examples:
+            official: rhel-6.8
+            staging: rhel-6.8-staging
+            private staging: private-<anything->rhel-6.8-staging<-anything>
+            private: john-feature-branch-bz123321
+
+        Returns:
+            One of the strings ['standard','staging','private','private staging']
+        """
+        if self.is_staging():
+            if self.name.startswith("private-"):
+                return "private staging"
+            else:
+                return "staging"
+        elif self.is_standard():
+            return "standard"
+
+        return "private"

--- a/build-on-push/platform_ci/platform_ci/distgit.py
+++ b/build-on-push/platform_ci/platform_ci/distgit.py
@@ -21,6 +21,16 @@ class DistGitBranchException(notifications.PlatformCIException):
     header = notifications.create_platform_error_header(notifications.HEADERS["DIST_GIT"])
 
 
+class DistGitCommit(object):
+    """The class represents a commit in the DistGit repository."""
+
+    # pylint: disable=too-few-public-methods
+    def __init__(self, commit_hash, branch_name, description):
+        self.hash = commit_hash
+        self.branch = DistGitBranch(branch_name)
+        self.description = description
+
+
 class DistGitBranch(object):
     """The class represents a DistGit branch.
 

--- a/build-on-push/platform_ci/platform_ci/distgit.py
+++ b/build-on-push/platform_ci/platform_ci/distgit.py
@@ -92,14 +92,15 @@ class DistGitBranch(object):
     def type(self):
         """Returns a type of the branch.
 
-        There are four branch types: official, staging, private, and private staging.
-        The type is determined from the branch name. A staging branch is named as a
-        standard branch with '-staging' suffix. A private staging branch is a well-named
-        private branch (with private- prefix) containing a name of a staging branch inside.
-        Any other name is considered to be private branch.
+        There are four branch types: standard, staging, private, and private staging.
+        The type is determined from the branch name. A standard branch is a RCM-owned
+        branch, usually matching a product version and with ACL enabled. A staging
+        branch is named as a standard branch with '-staging' suffix. A private staging
+        branch is a well-named private branch (with private- prefix) containing a name
+        of a staging branch inside. Any other name is considered to be a private branch.
 
         Examples:
-            official: rhel-6.8
+            standard: rhel-6.8
             staging: rhel-6.8-staging
             private staging: private-<anything->rhel-6.8-staging<-anything>
             private: john-feature-branch-bz123321

--- a/build-on-push/platform_ci/platform_ci/distgit_test.py
+++ b/build-on-push/platform_ci/platform_ci/distgit_test.py
@@ -1,0 +1,118 @@
+# Copyright 2016 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+# pylint: disable=no-name-in-module
+from nose.tools import assert_raises
+
+from .distgit import DistGitBranch, DistGitBranchException
+
+
+class DistGitBranchTest(unittest.TestCase):
+    STAGING = {"branch": "rhel-7.1-staging", "target": "rhel-7.1-candidate"}
+    PRIVATE = {"branch": "private-pmuller-branch", "target": None}
+    STANDARD = {"branch": "extras-rhel-7.2", "target": "extras-rhel-7.2-candidate"}
+    EXTRAS_STAGING = {"branch": "extras-rhel-7.2-staging", "target": "extras-rhel-7.2-candidate"}
+
+    def setUp(self):
+        self.staging_branch = DistGitBranch(DistGitBranchTest.STAGING["branch"])
+        self.private_branch = DistGitBranch(DistGitBranchTest.PRIVATE["branch"])
+        self.extras_staging_branch = DistGitBranch(DistGitBranchTest.EXTRAS_STAGING["branch"])
+        self.standard_branch = DistGitBranch(DistGitBranchTest.STANDARD["branch"])
+
+    def extras_staging_branch_test(self):
+        assert self.extras_staging_branch.name == DistGitBranchTest.EXTRAS_STAGING["branch"]
+        assert self.extras_staging_branch.is_staging()
+        assert self.extras_staging_branch.staging_target == DistGitBranchTest.EXTRAS_STAGING["target"]
+        assert self.extras_staging_branch.type == "staging"
+
+    def staging_branch_test(self):
+        assert self.staging_branch.name == DistGitBranchTest.STAGING["branch"]
+        assert self.staging_branch.is_staging()
+        assert self.staging_branch.staging_target == DistGitBranchTest.STAGING["target"]
+        assert self.staging_branch.type == "staging"
+
+    def private_branch_test(self):
+        assert self.private_branch.name == DistGitBranchTest.PRIVATE["branch"]
+        assert not self.private_branch.is_staging()
+        assert_raises(DistGitBranchException, lambda: self.private_branch.staging_target)
+        assert self.private_branch.type == "private"
+
+    def standard_branch_test(self):
+        assert self.standard_branch.name == DistGitBranchTest.STANDARD["branch"]
+        assert not self.standard_branch.is_staging()
+        print self.standard_branch.staging_target
+        assert self.standard_branch.staging_target == DistGitBranchTest.STANDARD["target"]
+        assert self.standard_branch.type == "standard"
+
+    # pylint: disable=no-self-use
+    def rhscl_staging_branch_test(self):
+        """
+        Tests for parsing staging branches for RHSCL and determining the correct build target
+        """
+        testing_branches = [
+            'rhscl-2.1-rh-ruby22-rhel-6-staging',
+            'rhscl-2.1-rh-ruby22-rhel-7-staging',
+            'rhscl-2.1-rh-mariadb100-rhel-6-staging',
+            'rhscl-2.1-rh-mariadb100-rhel-7-staging'
+        ]
+
+        testing_targets = [branch.replace('staging', 'candidate') for branch in testing_branches]
+
+        for branch, target in zip(testing_branches, testing_targets):
+            obj = DistGitBranch(branch)
+            assert obj.is_staging()
+            assert obj.staging_target == target
+            assert obj.type == "staging"
+
+    # pylint: disable=no-self-use
+    def private_rhscl_staging_branch_test(self):
+        """
+        Tests for parsing private staging branches for RHSCL and determining the correct build target
+        """
+        testing_data = [
+            ('private-johnfoo-rhscl-2.1-rh-ruby22-rhel-6-staging', 'rhscl-2.1-rh-ruby22-rhel-6-candidate'),
+            ('private-johnfoo-rhscl-2.1-rh-ruby22-rhel-7-staging-BZ123456', 'rhscl-2.1-rh-ruby22-rhel-7-candidate'),
+            ('private-rhscl-2.1-rh-mariadb100-rhel-6-staging-BZ654321', 'rhscl-2.1-rh-mariadb100-rhel-6-candidate'),
+            ('private-jo-fo-rhscl-2.1-rh-mariadb100-rhel-7-staging-bar-baz', 'rhscl-2.1-rh-mariadb100-rhel-7-candidate')
+        ]
+
+        for branch, target in testing_data:
+            obj = DistGitBranch(branch)
+            assert obj.is_staging()
+            assert obj.staging_target == target
+            assert obj.type == "private staging"
+
+    # pylint: disable=no-self-use
+    def private_staging_branch_test(self):
+        """
+        Tests for parsing private staging branches for RHEL components and determining the correct build target
+        """
+        testing_data = [
+            ('private-johnfoo-rhel-7.3-staging', 'rhel-7.3-candidate'),
+            ('private-johnfoo-rhel-7.3-staging-BZ123456', 'rhel-7.3-candidate'),
+            ('private-rhel-6.8-staging-BZ654321', 'rhel-6.8-candidate'),
+            ('private-jo-fo-rhel-6.8-staging-bar-baz', 'rhel-6.8-candidate'),
+            ('private-johnfoo-extras-rhel-7.3-staging', 'extras-rhel-7.3-candidate'),
+            ('private-johnfoo-extras-rhel-7.3-staging-BZ123456', 'extras-rhel-7.3-candidate'),
+            ('private-extras-rhel-6.8-staging-BZ654321', 'extras-rhel-6.8-candidate'),
+            ('private-jo-fo-extras-rhel-6.8-staging-bar-baz', 'extras-rhel-6.8-candidate'),
+        ]
+
+        for branch, target in testing_data:
+            obj = DistGitBranch(branch)
+            assert obj.is_staging()
+            assert obj.staging_target == target
+            assert obj.type == "private staging"

--- a/build-on-push/platform_ci/platform_ci/jenkins.py
+++ b/build-on-push/platform_ci/platform_ci/jenkins.py
@@ -1,0 +1,229 @@
+# Copyright 2016 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module provides an interface to the Jenkins instance providing
+Platform CI service.
+"""
+
+import os
+import subprocess
+import logging
+import platform_ci.jjb
+import platform_ci.notifications as notifications
+
+
+class PlatformJenkinsException(notifications.PlatformCIException):
+    """Exception thrown on errors during communication with a Jenkins instance."""
+    header = notifications.create_platform_error_header(notifications.HEADERS["JENKINS"])
+
+
+# pylint: disable=too-few-public-methods
+class PlatformJenkins(object):
+    """Represents a Platform CI Jenkins instance.
+
+    Provides methods for interacting with the Jenkins instance, mostly for job
+    manipulation (create, update, delete) but also others. The class is
+    basically a thin wrapper over a different, generic Jenkins API, extended
+    to be aware of the Platform CI concepts.
+    """
+    @classmethod
+    def get_jenkins(cls, url, template_dir=None):
+        """Returns an instance for a given Jenkins URL.
+
+        The returned instance is usually a instance of a PlatformJenkins
+        subclass (this allows to switch to a different Jenkins API.
+        """
+        return PlatformJenkinsJavaCLI(template_dir, url)
+
+    def __init__(self, jenkins, template_dir):
+        self.jenkins_server = jenkins
+        self.template_dir = template_dir
+
+
+class PlatformJenkinsJavaCLI(PlatformJenkins):
+    """Represents a Platform CI Jenkins instance, wrapping a Java CLI API.
+
+    While ugly to wrap the Java CLI in Python like this, we had the best
+    experience with using the Java CLI from all other Jenkins API options
+    that we tried, especially related to authentication.
+
+    If someone implements a replacement class over Python Jenkins API that
+    *works*, it would probably be best to replace this class with it.
+    """
+
+    CLI = ["/usr/bin/java", "-jar", "/var/lib/jenkins/jenkins-cli.jar", "-noCertificateCheck"]
+
+    GET_VIEW = "get-view"
+    UPDATE_VIEW = "update-view"
+    CREATE_VIEW = "create-view"
+
+    VIEW_TEMPLATE = "view-template.xml"
+
+    LIST_JOBS = "list-jobs"
+    DELETE_JOB = "delete-job"
+    BUILD_JOB = "build"
+    CREATE_JOB = "create-job"
+    UPDATE_JOB = "update-job"
+    ENABLE_JOB = "enable-job"
+    DISABLE_JOB = "disable-job"
+
+    SET_DESCRIPTION = "set-build-description"
+
+    def __init__(self, template_dir, url):
+        super(PlatformJenkinsJavaCLI, self).__init__(None, template_dir)
+        self.url = url
+        self.cli = []
+        if "BOP_JENKINS_CLI" in os.environ:
+            self.cli.extend(os.environ["BOP_JENKINS_CLI"].split())
+            self.cli.append("-noCertificateCheck")
+        else:
+            self.cli.extend(PlatformJenkinsJavaCLI.CLI)
+
+        self.cli.extend(["-s", url])
+
+    def view_exists(self, view):
+        """Returns true if a given view exists."""
+        with open("/dev/null", "w") as devnull:
+            call = subprocess.Popen(self.cli + [PlatformJenkinsJavaCLI.GET_VIEW, view], stdout=devnull, stderr=devnull)
+            call.wait()
+        return call.returncode == 0
+
+    def set_view(self, view, view_xml_filename):
+        """Creates a View, defined by XML in view_xml_filename.
+
+        If the file exists, it will be update using the provided definition.
+
+        Args:
+            view: Created view name
+            view_xml_filename: Path to a file containing a XML definition of a view.
+        """
+        if self.view_exists(view):
+            command = PlatformJenkinsJavaCLI.UPDATE_VIEW
+        else:
+            command = PlatformJenkinsJavaCLI.CREATE_VIEW
+
+        with open(view_xml_filename) as view_xml_file:
+            view_xml = view_xml_file.read()
+
+        call = subprocess.Popen(self.cli + [command, view], stdin=subprocess.PIPE)
+        call.communicate(view_xml)
+        call.wait()
+
+    def job_exists(self, job):
+        """Returns True if the given job exists."""
+        call = subprocess.Popen(self.cli + [PlatformJenkinsJavaCLI.LIST_JOBS], stdout=subprocess.PIPE)
+        out = call.communicate()[0]
+        out = out.split("\n")
+        return job.name in out or job.display_name in out
+
+    def delete_job(self, job):
+        """Deletes a given job from Jenkins."""
+        subprocess.call(self.cli + [PlatformJenkinsJavaCLI.DELETE_JOB, job.name])
+
+    def trigger_job(self, job, parameters=None):
+        """Triggers given job, providing a set of parameters to it.
+
+        Raises:
+            PlatformJenkinsException: Triggering the job failed: either the job
+                does not exist, is disabled, or there was a communication
+                error.
+        """
+        parameters = parameters or {}
+        parameter_list = []
+        for key in parameters:
+            parameter_list.append("-p")
+            parameter_list.append("%s=%s" % (key, parameters[key]))
+        if subprocess.call(self.cli + [PlatformJenkinsJavaCLI.BUILD_JOB, job.name] + parameter_list) != 0:
+            raise PlatformJenkinsException("Triggering job failed: " + job.name)
+
+    def enable_job(self, job):
+        """Enables given job on Jenkins.
+
+        Raises:
+            PlatformJenkinsException: Enabling the job failed: either the job
+                does not exist, or there was some communication error."""
+        if subprocess.call(self.cli + [PlatformJenkinsJavaCLI.ENABLE_JOB, job.name]) != 0:
+            raise PlatformJenkinsException("Enabling job failed: " + job.name)
+
+    def disable_job(self, job):
+        """Disables given job on Jenkins.
+
+        Raises:
+            PlatformJenkinsException: Disabling the job failed: either the job
+                does not exist, or there was some communication error.
+        """
+        if subprocess.call(self.cli + [PlatformJenkinsJavaCLI.DISABLE_JOB, job.name]) != 0:
+            raise PlatformJenkinsException("Disabling job failed: " + job.name)
+
+    def create_job(self, job):
+        """Create a given job on Jenkins.
+
+        Raises:
+            PlatformJenkinsException: Disabling the job failed: either the job
+                exists already, or there was some communication error.
+        """
+        call = subprocess.Popen(self.cli + [PlatformJenkinsJavaCLI.CREATE_JOB, job.name], stdin=subprocess.PIPE)
+        out, err = call.communicate(input=platform_ci.jjb.get_job_as_xml(job, self.template_dir))
+        call.wait()
+        if call.returncode != 0:
+            logging.info(out)
+            logging.error(err)
+            raise PlatformJenkinsException("Creating job failed: " + job.name)
+
+    def update_job(self, job):
+        """Update a given job on Jenkins.
+
+        Raises:
+            PlatformJenkinsException: Updating the job failed: either the job
+                does not exist, or there was some communication error.
+        """
+        call = subprocess.Popen(self.cli + [PlatformJenkinsJavaCLI.UPDATE_JOB, job.name], stdin=subprocess.PIPE)
+        call.communicate(input=platform_ci.jjb.get_job_as_xml(job, self.template_dir))
+        call.wait()
+        if call.returncode != 0:
+            raise PlatformJenkinsException("Updating job failed: " + job.name)
+
+    def set_build_description(self, job_name, build, description):
+        """Updates a job build description.
+
+        Args:
+            job_name: Name of a job
+            build: Build number of a build of job_name
+            description: Description to be set
+
+        Raises:
+            PlatformJenkinsException: Setting the description failed: either the
+            job_name/build are wrong, or there was some communication problem.
+        """
+        try:
+            subprocess.check_call(self.cli + [PlatformJenkinsJavaCLI.SET_DESCRIPTION, job_name, build, description])
+        except subprocess.CalledProcessError:
+            message = "Setting build description failed (job={0}, build={1}, description='{2}')".format(job_name,
+                                                                                                        build,
+                                                                                                        description)
+            raise PlatformJenkinsException(message)
+
+    def set_current_build_description(self, description):
+        """Updates a job build description for the current build.
+
+        This method is intended to be run in an environment where JOB_NAME
+        and BUILD_NUMBER are set in the environment, such as from within the
+        job build itself. If either of the environment variables is not set,
+        setting the description is not attempted at all.
+        """
+        job_name = os.environ.get("JOB_NAME", None)
+        build_id = os.environ.get("BUILD_NUMBER", None)
+        if job_name is not None and build_id is not None:
+            self.set_build_description(job_name, build_id, description)

--- a/build-on-push/platform_ci/platform_ci/jenkins.py
+++ b/build-on-push/platform_ci/platform_ci/jenkins.py
@@ -171,7 +171,7 @@ class PlatformJenkinsJavaCLI(PlatformJenkins):
         """Create a given job on Jenkins.
 
         Raises:
-            PlatformJenkinsException: Disabling the job failed: either the job
+            PlatformJenkinsException: Creating the job failed: either the job
                 exists already, or there was some communication error.
         """
         call = subprocess.Popen(self.cli + [PlatformJenkinsJavaCLI.CREATE_JOB, job.name], stdin=subprocess.PIPE)

--- a/build-on-push/platform_ci/platform_ci/jenkins.py
+++ b/build-on-push/platform_ci/platform_ci/jenkins.py
@@ -71,13 +71,13 @@ class PlatformJenkinsJavaCLI(PlatformJenkins):
 
     VIEW_TEMPLATE = "view-template.xml"
 
-    LIST_JOBS = "list-jobs"
     DELETE_JOB = "delete-job"
     BUILD_JOB = "build"
     CREATE_JOB = "create-job"
     UPDATE_JOB = "update-job"
     ENABLE_JOB = "enable-job"
     DISABLE_JOB = "disable-job"
+    GET_JOB = "get-job"
 
     SET_DESCRIPTION = "set-build-description"
 
@@ -123,10 +123,11 @@ class PlatformJenkinsJavaCLI(PlatformJenkins):
 
     def job_exists(self, job):
         """Returns True if the given job exists."""
-        call = subprocess.Popen(self.cli + [PlatformJenkinsJavaCLI.LIST_JOBS], stdout=subprocess.PIPE)
-        out = call.communicate()[0]
-        out = out.split("\n")
-        return job.name in out or job.display_name in out
+
+        with open(os.devnull, 'w') as devnull:
+            result = subprocess.call(self.cli + [PlatformJenkinsJavaCLI.GET_JOB, job.name], stdout=devnull)
+
+        return result == 0
 
     def delete_job(self, job):
         """Deletes a given job from Jenkins."""

--- a/build-on-push/platform_ci/platform_ci/jenkins.py
+++ b/build-on-push/platform_ci/platform_ci/jenkins.py
@@ -21,6 +21,7 @@ import os
 import subprocess
 import logging
 import platform_ci.jjb
+import platform_ci.config
 import platform_ci.notifications as notifications
 
 
@@ -85,8 +86,11 @@ class PlatformJenkinsJavaCLI(PlatformJenkins):
         super(PlatformJenkinsJavaCLI, self).__init__(None, template_dir)
         self.url = url
         self.cli = []
-        if "BOP_JENKINS_CLI" in os.environ:
-            self.cli.extend(os.environ["BOP_JENKINS_CLI"].split())
+
+        config = platform_ci.config.PlatformCIConfig()
+
+        if config.jenkins_cli_path:
+            self.cli.extend(config.jenkins_cli_path.split())
             self.cli.append("-noCertificateCheck")
         else:
             self.cli.extend(PlatformJenkinsJavaCLI.CLI)

--- a/build-on-push/platform_ci/platform_ci/jenkins_jobs.py
+++ b/build-on-push/platform_ci/platform_ci/jenkins_jobs.py
@@ -1,0 +1,191 @@
+# Copyright 2016 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This module contains representations of the individual Jenkins job "types"""
+
+import os
+import yaml
+
+import platform_ci.notifications as notifications
+
+
+# pylint: disable=too-few-public-methods
+class JenkinsJobError(notifications.PlatformCIException):
+    """Exception to be used on errors during work with Jenkins jobs."""
+    header = notifications.create_platform_error_header()
+
+
+class JobBuildOnCommit(object):
+    """Represents a Build-on-Push worker job.
+
+    The worker job issues scratch build requests in Brew. For a component,
+    there should be a single Worker job per DistGit branch, so it's build
+    history represents a build-ability of that branch in history.
+    """
+    def __init__(self, component, branch, slave, platform_ci_repo, platform_ci_branch):
+        self.component = component
+        self.branch = branch
+        self.slave = slave
+        self.platform_ci_branch = platform_ci_branch
+        self.platform_ci_repo = platform_ci_repo
+
+    @staticmethod
+    def create_job_name(component, branch):
+        """Creates a name of a job.
+
+        This method exists so that call-sites without the information about
+        further details about a Worker job (such as slave and Platform CI repo
+        branch) can construct names of jobs, so that they can e.g. trigger them.
+
+        Args:
+            Component: Component name
+            Branch: DistGit branch name
+
+        Returns:
+            Name of the Worker job for a given component and branch
+        """
+        return "ci-%s-commit-%s" % (component, branch)
+
+    @property
+    def name(self):
+        """Returns the name of the Jenkins job represented by this instance."""
+        return JobBuildOnCommit.create_job_name(self.component, self.branch)
+
+    @property
+    def display_name(self):
+        """Returns the human-oriented label of the job represented by an instance."""
+        return "{0}: Build branch {1} in Brew".format(self.component, self.branch)
+
+    def as_yaml(self):
+        """Returns a YAML string usable for instantiation of the JJB template.
+
+        The output is the YAML with values which can be used to instantiate
+        the 'ci-workflow-brew-build' template to create a Jenkins job using the
+        Jenkins Job Builder.
+        """
+
+        # TODO: These settings should be centralized somewhere else
+        if "PLATFORM_CI_PROJECT" in os.environ:
+            platform_ci_project_link = '<a href="{0}">Platform CI Project</a>'.format(os.environ["PLATFORM_CI_PROJECT"])
+        else:
+            platform_ci_project_link = "Platform CI Project"
+
+        if "BOP_DIST_GIT_URL" in os.environ:
+            distgit_root = os.environ["BOP_DIST_GIT_URL"]
+        else:
+            raise JenkinsJobError("BOP_DIST_GIT_URL not set: cannot create a commit worker job")
+
+        if "JENKINS_URL" in os.environ:
+            dispatcher_name = JobCommitDispatcher.create_job_name(self.component)
+            dispatcher_link = '<a href="{0}/job/{1}">commit dispatcher</a>'.format(os.environ["JENKINS_URL"],
+                                                                                   dispatcher_name)
+        else:
+            dispatcher_link = 'commit dispatcher'
+
+        template = {"job-template": {"name": self.name, "defaults": "ci-workflow-brew-build"}}
+        project = {"project": {"name": self.component, "component": self.component, "jobs": [self.name],
+                               "git-branch": self.branch, "display-name": self.display_name, "team-slave": self.slave,
+                               "platform-ci-branch": self.platform_ci_branch, 'dispatcher-link': dispatcher_link,
+                               "platform-ci-project-link": platform_ci_project_link, "distgit-root-url": distgit_root,
+                               "github-user": self.platform_ci_repo}}
+
+        return yaml.dump([template, project], default_flow_style=False)
+
+
+class JobCommitDispatcher(object):
+    """Represents the Build-on-Push dispatcher job.
+
+    The dispatcher job monitors all changes in a DistGit repository for a given
+    component, and based on the branch where the changes were made, decides if
+    the testing scratch-build should be automatically attempted. There should be
+    a single dispatcher job per component.
+    """
+    def __init__(self, component, slave=None, platform_ci_repo=None, platform_ci_branch=None):
+        self.component = component
+        self.slave = slave
+        self.platform_ci_branch = platform_ci_branch
+        self.platform_ci_repo = platform_ci_repo
+
+    @staticmethod
+    def create_description(branch, built_targets, jenkins_url, component):
+        """Creates a build description for the dispatcher job.
+
+        Args:
+            branch: A name of the branch with the commits triggering the dispatcher
+            built_targets: A list of targets that were decided to build
+            jenkins_url: The URL of the Jenkins master where the description will be viewed.
+            component: A name of the component
+        Returns:
+            A string with the HTML fragment suitable to be used as a Jenkins job build
+                description
+        """
+        lines = ["<strong>Dist-git branch</strong>: {0.name} ({0.type} branch)".format(branch)]
+
+        if not built_targets:
+            lines.append("No brew build was issued ({0.name} is not handled by CI)".format(branch))
+        else:
+            trigger_job_template = '<strong>Triggered job: </strong><a href="{0}/job/{1}">Worker job for branch {2}</a>'
+            worker_job_name = JobBuildOnCommit.create_job_name(component, branch.name)
+            trigger_job_message = trigger_job_template.format(jenkins_url, worker_job_name, branch.name)
+            lines.append(trigger_job_message)
+
+        return "<p>{0}</p>".format("<br>".join(lines))
+
+    @staticmethod
+    def create_job_name(component):
+        return "ci-{0}-dispatcher-commit".format(component)
+
+    @property
+    def name(self):
+        """Returns the name of the job represented by an instance."""
+        return JobCommitDispatcher.create_job_name(self.component)
+
+    @property
+    def display_name(self):
+        """Returns the (human-oriented) label of a job represented by an instance."""
+        return "{0}: Schedule Brew build".format(self.component)
+
+    def as_yaml(self):
+        """Returns a YAML string usable for instantiation of the JJB template.
+
+        The output is the YAML with values which can be used to instantiate
+        the 'ci-dispatcher-commit' template to create a Jenkins job using the
+        Jenkins Job Builder.
+        """
+
+        # TODO: These settings should be centralized somewhere else
+        if "PLATFORM_CI_PROJECT" in os.environ:
+            platform_ci_project_link = '<a href="{0}">Platform CI Project</a>'.format(os.environ["PLATFORM_CI_PROJECT"])
+        else:
+            platform_ci_project_link = "Platform CI Project"
+
+        if "BOP_DIST_GIT_URL" in os.environ:
+            distgit_root = os.environ["BOP_DIST_GIT_URL"]
+        else:
+            raise JenkinsJobError("BOP_DIST_GIT_URL not set: cannot create a commit dispatcher job")
+
+        if "BOP_STAGING_BRANCH_DOC" in os.environ:
+            staging_branch_doc_link = '<a href="{0}">staging branch</a>'.format(os.environ["BOP_STAGING_BRANCH_DOC"])
+        else:
+            staging_branch_doc_link = "staging branch"
+
+        template = {"job-template": {"name": self.name, "defaults": 'ci-dispatcher-commit'}}
+        project = {"project": {"name": self.component, "component": self.component, "jobs": [self.name],
+                               "display-name": self.display_name, "team-slave": self.slave,
+                               "platform-ci-branch": self.platform_ci_branch, "distgit-root-url": distgit_root,
+                               "platform-ci-project-link": platform_ci_project_link,
+                               "staging-branch-doc-link": staging_branch_doc_link,
+                               "github-user": self.platform_ci_repo}}
+
+        return yaml.dump([template, project], default_flow_style=False)

--- a/build-on-push/platform_ci/platform_ci/jenkins_jobs_test.py
+++ b/build-on-push/platform_ci/platform_ci/jenkins_jobs_test.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import unittest
-import yaml
 import os
+import yaml
 from .jenkins_jobs import JobBuildOnCommit, JobCommitDispatcher
 from .ci_types import PlatformCISource
 

--- a/build-on-push/platform_ci/platform_ci/jenkins_jobs_test.py
+++ b/build-on-push/platform_ci/platform_ci/jenkins_jobs_test.py
@@ -1,0 +1,71 @@
+# Copyright 2016 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import yaml
+import os
+from .jenkins_jobs import JobBuildOnCommit, JobCommitDispatcher
+
+
+# pylint: disable=too-many-public-methods
+class JobBuildOnCommitTest(unittest.TestCase):
+
+    def setUp(self):
+        self.component = "glibc"
+        self.branch = "rhel-7.1"
+        self.slave = "slave-name"
+        self.platform_ci_branch = "test-branch"
+        self.github_user = "QEOS"
+
+        self.job = JobBuildOnCommit(self.component, self.branch, self.slave, self.github_user, self.platform_ci_branch)
+
+    def test_sanity(self):
+        assert self.component == self.job.component
+        assert self.job.name == "ci-%s-commit-%s" % (self.component, self.branch)
+        assert self.branch == self.job.branch
+        assert self.slave == self.job.slave
+        assert self.job.display_name == "glibc: Build branch rhel-7.1 in Brew"
+
+    def test_as_yaml(self):
+        os.environ["BOP_DIST_GIT_URL"] = "git://fake/url"
+        as_yaml = self.job.as_yaml()
+        reconstructed = yaml.load(as_yaml)
+        assert len(reconstructed) == 2
+
+
+class JobCommitDispatcherTest(unittest.TestCase):
+    def setUp(self):
+        self.component1 = "glibc"
+        self.component2 = "gcc"
+        self.slave = "slave-name"
+        self.platform_ci_branch = "test-branch"
+        self.github_user = "RHQE"
+        self.job_component1 = JobCommitDispatcher(self.component1, self.slave, self.github_user,
+                                                  self.platform_ci_branch)
+        self.job_component2 = JobCommitDispatcher(self.component2, self.slave, self.github_user,
+                                                  self.platform_ci_branch)
+
+    def test_slave(self):
+        assert self.slave == self.job_component1.slave
+
+    def test_platform_ci_branch(self):
+        assert self.platform_ci_branch == self.job_component1.platform_ci_branch
+
+    def test_name(self):
+        assert "ci-{0}-dispatcher-commit".format(self.component1) == self.job_component1.name
+        assert "ci-{0}-dispatcher-commit".format(self.component2) == self.job_component2.name
+
+    def test_display_name(self):
+        assert "{0}: Schedule Brew build".format(self.component1) == self.job_component1.display_name
+        assert "{0}: Schedule Brew build".format(self.component2) == self.job_component2.display_name

--- a/build-on-push/platform_ci/platform_ci/jenkins_jobs_test.py
+++ b/build-on-push/platform_ci/platform_ci/jenkins_jobs_test.py
@@ -16,6 +16,7 @@ import unittest
 import yaml
 import os
 from .jenkins_jobs import JobBuildOnCommit, JobCommitDispatcher
+from .ci_types import PlatformCISource
 
 
 # pylint: disable=too-many-public-methods
@@ -27,8 +28,9 @@ class JobBuildOnCommitTest(unittest.TestCase):
         self.slave = "slave-name"
         self.platform_ci_branch = "test-branch"
         self.github_user = "QEOS"
+        self.platform_ci_source = PlatformCISource(self.github_user, self.platform_ci_branch)
 
-        self.job = JobBuildOnCommit(self.component, self.branch, self.slave, self.github_user, self.platform_ci_branch)
+        self.job = JobBuildOnCommit(self.component, self.branch, self.slave, self.platform_ci_source)
 
     def test_sanity(self):
         assert self.component == self.job.component
@@ -50,17 +52,15 @@ class JobCommitDispatcherTest(unittest.TestCase):
         self.component2 = "gcc"
         self.slave = "slave-name"
         self.platform_ci_branch = "test-branch"
-        self.github_user = "RHQE"
-        self.job_component1 = JobCommitDispatcher(self.component1, self.slave, self.github_user,
-                                                  self.platform_ci_branch)
-        self.job_component2 = JobCommitDispatcher(self.component2, self.slave, self.github_user,
-                                                  self.platform_ci_branch)
+        self.platform_ci_source = PlatformCISource("RHQE", self.platform_ci_branch)
+        self.job_component1 = JobCommitDispatcher(self.component1, self.slave, self.platform_ci_source)
+        self.job_component2 = JobCommitDispatcher(self.component2, self.slave, self.platform_ci_source)
 
     def test_slave(self):
         assert self.slave == self.job_component1.slave
 
     def test_platform_ci_branch(self):
-        assert self.platform_ci_branch == self.job_component1.platform_ci_branch
+        assert self.platform_ci_branch == self.job_component1.platform_ci_source.branch
 
     def test_name(self):
         assert "ci-{0}-dispatcher-commit".format(self.component1) == self.job_component1.name

--- a/build-on-push/platform_ci/platform_ci/jenkins_test.py
+++ b/build-on-push/platform_ci/platform_ci/jenkins_test.py
@@ -1,0 +1,217 @@
+# Copyright 2016 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from sys import version_info
+import unittest
+import tempfile
+import os
+
+from mock import MagicMock, patch
+# pylint: disable=no-name-in-module
+from nose.tools import assert_raises
+
+from .jenkins import PlatformJenkins
+from .jenkins_jobs import JobCommitDispatcher
+import platform_ci.jenkins
+
+# pylint: disable=no-member
+try:
+    major = version_info.major
+except AttributeError:
+    major = version_info[0]
+
+# pylint: disable=import-error,wrong-import-order,wrong-import-position
+if major == 2:
+    import __builtin__ as builtins
+else:
+    import builtins
+
+
+# pylint: disable=too-many-public-methods
+class PlatformJenkinsTest(unittest.TestCase):
+    def setUp(self):
+        self.template_dir = tempfile.mkdtemp()
+        self.jenkins_mock = MagicMock()
+        self.job_mock = MagicMock()
+        self.url = "testing-url"
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        os.rmdir(self.template_dir)
+
+    def get_jenkins_test(self):
+        jenkins = PlatformJenkins.get_jenkins(self.url, self.template_dir)
+        assert jenkins.jenkins_server is None
+        assert jenkins.template_dir == self.template_dir
+        assert jenkins.url == self.url
+
+
+class PlatformJenkinsJavaCLITest(unittest.TestCase):
+    def setUp(self):
+        self.template_dir = tempfile.mkdtemp()
+        self.job_mock = JobCommitDispatcher("component", "slave", "branch")
+        self.jenkins = platform_ci.jenkins.PlatformJenkinsJavaCLI(self.template_dir, "url")
+        self.job = MagicMock()
+        self.job.name = "job_name"
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        os.rmdir(self.template_dir)
+
+    @patch('subprocess.Popen')
+    def view_exists_test(self, mock_popen):
+        self.jenkins.view_exists("view")
+        assert mock_popen.called
+        command = mock_popen.call_args[0][0]
+        assert command == (self.jenkins.cli + [platform_ci.jenkins.PlatformJenkinsJavaCLI.GET_VIEW, "view"])
+
+    @patch('subprocess.call')
+    def enable_job_test(self, mock_call):
+        mock_call.return_value = 0
+        self.jenkins.enable_job(self.job_mock)
+        assert mock_call.called
+        command = mock_call.call_args[0][0]
+        assert command == self.jenkins.cli + [platform_ci.jenkins.PlatformJenkinsJavaCLI.ENABLE_JOB, self.job_mock.name]
+
+        mock_call.reset_mock()
+        mock_call.return_value = 1
+        assert_raises(platform_ci.jenkins.PlatformJenkinsException, self.jenkins.enable_job, self.job)
+
+    @patch.object(builtins, 'open')
+    @patch('platform_ci.jenkins.PlatformJenkinsJavaCLI.view_exists')
+    @patch('subprocess.Popen')
+    def set_view_test(self, mock_popen, mock_view_exists, mock_open):
+        # view exists -> testing view update
+        mock_view_exists.return_value = True
+
+        self.jenkins.set_view("view", "mock-file")
+        assert mock_view_exists.called
+        assert mock_popen.called
+        command = mock_popen.call_args[0][0]
+        assert command == (self.jenkins.cli + [platform_ci.jenkins.PlatformJenkinsJavaCLI.UPDATE_VIEW, "view"])
+
+        assert mock_open.called
+        opened = mock_open.call_args[0][0]
+        assert opened == "mock-file"
+
+        mock_popen.reset_mock()
+        mock_view_exists.reset_mock()
+
+        # view does not exist -> testing view create
+        mock_view_exists.return_value = False
+
+        self.jenkins.set_view("view", "mock-file")
+        assert mock_view_exists.called
+        assert mock_popen.called
+        command = mock_popen.call_args[0][0]
+        print command
+        assert command == (self.jenkins.cli + [platform_ci.jenkins.PlatformJenkinsJavaCLI.CREATE_VIEW, "view"])
+
+    @patch('subprocess.Popen')
+    def job_exists_test(self, mock_popen):
+        mock_popen_instance = MagicMock()
+        mock_popen_instance.communicate = MagicMock()
+        mock_popen_instance.communicate.return_value = ["job1\njob2"]
+
+        mock_popen.return_value = mock_popen_instance
+
+        self.job.name = "job1"
+        assert self.jenkins.job_exists(self.job)
+        self.job.name = "job3"
+        assert not self.jenkins.job_exists(self.job)
+
+        assert mock_popen.called
+        command = mock_popen.call_args[0][0]
+        assert command == (self.jenkins.cli + [platform_ci.jenkins.PlatformJenkinsJavaCLI.LIST_JOBS])
+
+    @patch('subprocess.call')
+    def delete_job_test(self, mock_call):
+        self.jenkins.delete_job(self.job)
+        assert mock_call.called
+        command = mock_call.call_args[0][0]
+        assert command == (self.jenkins.cli + [platform_ci.jenkins.PlatformJenkinsJavaCLI.DELETE_JOB, self.job.name])
+
+    @patch('subprocess.call')
+    def trigger_job_test(self, mock_call):
+        mock_call.return_value = 0
+
+        self.jenkins.trigger_job(self.job)
+        assert mock_call.called
+        command = mock_call.call_args[0][0]
+        assert command == (self.jenkins.cli + [platform_ci.jenkins.PlatformJenkinsJavaCLI.BUILD_JOB, self.job.name])
+
+        mock_call.reset_mock()
+
+        self.jenkins.trigger_job(self.job, {"param1": "param1-value", "param2": "param2-value"})
+        assert mock_call.called
+        command = mock_call.call_args[0][0]
+        assert sorted(command) == sorted(self.jenkins.cli + [platform_ci.jenkins.PlatformJenkinsJavaCLI.BUILD_JOB,
+                                                             self.job.name, "-p", "param1=param1-value", "-p",
+                                                             "param2=param2-value"])
+
+        mock_call.return_value = 1
+        assert_raises(platform_ci.jenkins.PlatformJenkinsException, self.jenkins.trigger_job, self.job)
+
+    @patch('platform_ci.jjb.get_job_as_xml')
+    @patch('subprocess.Popen')
+    def create_job_test(self, mock_popen, mock_gjax):
+        mock_popen_instance = MagicMock()
+        mock_popen.return_value = mock_popen_instance
+
+        mock_popen_instance.returncode = 0
+        mock_popen_instance.communicate = MagicMock()
+        mock_popen_instance.communicate.return_value = ("stdout", "stderr")
+
+        mock_gjax.return_value = "job as xml"
+
+        self.jenkins.create_job(self.job)
+
+        assert mock_popen.called
+        command = mock_popen.call_args[0][0]
+        assert sorted(command) == sorted(self.jenkins.cli + [platform_ci.jenkins.PlatformJenkinsJavaCLI.CREATE_JOB,
+                                                             self.job.name])
+        assert mock_gjax.called
+        assert mock_popen_instance.communicate.called
+
+        communicate = mock_popen_instance.communicate.call_args[1]
+        assert communicate == {"input": mock_gjax.return_value}
+
+        mock_popen_instance.returncode = 1
+        assert_raises(platform_ci.jenkins.PlatformJenkinsException, self.jenkins.create_job, self.job)
+
+    @patch('platform_ci.jjb.get_job_as_xml')
+    @patch('subprocess.Popen')
+    def update_job_test(self, mock_popen, mock_gjax):
+        mock_popen_instance = MagicMock()
+        mock_popen.return_value = mock_popen_instance
+
+        mock_popen_instance.returncode = 0
+        mock_popen_instance.communicate = MagicMock()
+
+        mock_gjax.return_value = "job as xml"
+
+        self.jenkins.update_job(self.job)
+
+        assert mock_popen.called
+        command = mock_popen.call_args[0][0]
+        assert sorted(command) == sorted(self.jenkins.cli + [platform_ci.jenkins.PlatformJenkinsJavaCLI.UPDATE_JOB,
+                                                             self.job.name])
+        assert mock_gjax.called
+        assert mock_popen_instance.communicate.called
+
+        communicate = mock_popen_instance.communicate.call_args[1]
+        assert communicate == {"input": mock_gjax.return_value}
+
+        mock_popen_instance.returncode = 1
+        assert_raises(platform_ci.jenkins.PlatformJenkinsException, self.jenkins.update_job, self.job)

--- a/build-on-push/platform_ci/platform_ci/jjb.py
+++ b/build-on-push/platform_ci/platform_ci/jjb.py
@@ -1,0 +1,64 @@
+# Copyright 2016 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module provides a very thin wrapper over the Jenkins Job Builder. It's
+sole purpose is to generate instantiated job XML definitions using the JJB
+'test' command.
+"""
+
+import tempfile
+import os
+import shutil
+import subprocess
+
+
+def get_job_as_xml(job, template_dir):
+    """Returns a instantiated definition of a Jenkins job in XML format.
+
+    Args:
+        job: A Jenkins Job object to be instantiated
+        template_dir: A path to a directory containing job templates
+
+    Returns:
+        A string with the XML definition of a Jenkins job, suitable to be
+            used as an input for Jenkins API to create/update a job.
+    """
+    with JJB(template_dir) as jjbuilder:
+        jobxml = jjbuilder.get_job_as_xml(job)
+    return jobxml
+
+
+# pylint: disable=too-few-public-methods
+class JJB(object):
+    def __init__(self, template_dir):
+        self.template_dir = template_dir
+        self.workdir = tempfile.mkdtemp()
+
+    def __enter__(self):
+        for item in os.listdir(self.template_dir):
+            shutil.copy(os.path.join(self.template_dir, item), self.workdir)
+
+        return self
+
+    def __exit__(self, type_param, value, traceback):
+        shutil.rmtree(self.workdir)
+
+    def get_job_as_xml(self, job):
+        with open(os.path.join(self.workdir, "%s.yaml" % job.name), "w") as job_file:
+            job_file.write(job.as_yaml())
+
+        jjb = subprocess.Popen(["jenkins-jobs", "test", self.workdir, job.name], stdout=subprocess.PIPE)
+        jjb_xml = jjb.communicate()[0]
+        return jjb_xml

--- a/build-on-push/platform_ci/platform_ci/jjb_test.py
+++ b/build-on-push/platform_ci/platform_ci/jjb_test.py
@@ -1,0 +1,22 @@
+# Copyright 2016 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from .jenkins_jobs import JobCommitDispatcher
+
+
+# pylint: disable=too-many-public-methods
+class JJBTest(unittest.TestCase):
+    def setUp(self):
+        self.mock_job = JobCommitDispatcher("component", "slave", "platform-branch")

--- a/build-on-push/platform_ci/platform_ci/notifications.py
+++ b/build-on-push/platform_ci/platform_ci/notifications.py
@@ -1,0 +1,218 @@
+# Copyright 2016 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Notifications: Common notification message construction.
+
+This module implements a message construction mechanisms than can be called
+from any callsite in the Platform CI framework, so that the notifications are
+consistent for the user and error handling is easy to implement for
+the developers: it's just a matter of throwing a exception.
+
+The mechanism consists of two parts: the exceptions and message templates.
+The exceptions inheriting from the BaseCIException class carry additional
+data members which allow them, when caught, to embed the actual error message
+into a reasonable notification email with additional context.
+"""
+
+import os
+import textwrap
+
+from string import Template
+
+HEADERS = {"GENERIC_CI": "An error has occurred and the desired action was not performed correctly. "
+                         "Please contact the administrators of this CI instance.",
+           "CONTACTS_CI": "An error has occurred and no tests were reliably executed. ",
+           "BREW_BUILD": "There was a problem during a Brew build attempt. ",
+           "DIST_GIT": "There was a problem with dist-git manipulation. ",
+           "JENKINS": "An error has occurred while communicating with Jenkins. "}
+
+
+PLATFORM_CI_ADMINS = "Platform CI administrators"
+
+
+def create_platform_error_header(header_title=HEADERS["CONTACTS_CI"]):
+    """Creates a header for a error notification message.
+
+    There are multiple possible headers, depending on what happened (transient
+    infrastructure problem may need a different explanation than a CI framework
+    bug).
+
+    The actual header is consisting from an explanatory message (what happened)
+    and a call to action (what to do). Information needed for the header
+    construction are collected from the environment, if available.
+
+    Args:
+        header_title: An explanatory message for a class of possible errors
+
+    Returns:
+        A string with header to be included in an email notification.
+    """
+
+    call_to_action = "Please contact {admins} or file a bug{destination}."
+
+    if "PLATFORM_CI_ADMINS" in os.environ:
+        admins = "{0} ({1})".format(PLATFORM_CI_ADMINS, os.environ["PLATFORM_CI_ADMINS"])
+    else:
+        admins = PLATFORM_CI_ADMINS
+
+    if "PLATFORM_CI_BUG_DESTINATION" in os.environ:
+        destination = " at {0}".format(os.environ["PLATFORM_CI_BUG_DESTINATION"])
+    else:
+        destination = ""
+
+    template = header_title + call_to_action
+    return template.format(admins=admins, destination=destination)
+
+
+class BaseCIException(Exception):
+    """This class serves as a base of a hierarchy of the CI-related errors.
+
+    The class carries one additional member, *header*. This member is used
+    by the code generating the full messages from the caught exceptions.
+    """
+    header = HEADERS["GENERIC_CI"]
+
+
+class PlatformCIException(BaseCIException):
+    """This exception has a more specific call to action for Platform CI users"""
+    header = create_platform_error_header(HEADERS["CONTACTS_CI"])
+
+
+# pylint: disable=too-few-public-methods
+class BrewBuildsErrorNotification(object):
+    """Constructs a full error notification message body.
+
+    The message contains the information about a class of an encountered error,
+    specific error message, and also the component, Brew target and DistGit
+    branch involved in the failed operation. It contains a URL to the Jenkins
+    build console log.
+    """
+
+    TEMPLATE = """$header
+
+Component:     $component
+Branch:        $branch
+Brew targets:  $targets
+
+Error message: $message
+
+Debug log: $debug
+
+--
+$project_page
+"""
+
+    def __init__(self, header, error_message, component, branch, targets):
+        self.component = component
+        self.branch = branch
+        self.targets = " ".join(targets)
+        self.message = error_message
+        self.header = "\n".join(textwrap.wrap(header))
+
+        if "BUILD_URL" in os.environ:
+            self.debug = "%s/console" % os.environ["BUILD_URL"]
+        else:
+            self.debug = "unknown"
+
+        if "PLATFORM_CI_PROJECT" in os.environ:
+            self.project_page = "CI Project page: {0}".format(os.environ["PLATFORM_CI_PROJECT"])
+        else:
+            self.project_page = ""
+
+    def __str__(self):
+        template = Template(BrewBuildsErrorNotification.TEMPLATE)
+        return template.substitute(header=self.header, component=self.component, branch=self.branch,
+                                   targets=self.targets, message=str(self.message), debug=self.debug,
+                                   project_page=self.project_page)
+
+
+# pylint: disable=too-few-public-methods
+class IndividualBrewBuildResults(object):
+    """Constructs individual build attempt result lines for notifications."""
+    def __init__(self, builds):
+        self.builds = builds
+
+    def __str__(self):
+        items = []
+        for result in self.builds.all():
+            url = result.url
+            if url is None:
+                if "BUILD_URL" in os.environ:
+                    url = "{0}/artifact/{1}".format(os.environ["BUILD_URL"], os.path.basename(result.logfile_path))
+                else:
+                    url = "No URL available"
+            else:
+                url = url.strip()
+            items.append("  {0} : {1} ({2})".format(result.target, result.short_result, url))
+        return "\n".join(items)
+
+
+class BrewBuildsNotification(object):
+    """Constructs full notification message.
+
+    This class constructs a message used when the Brew build requests were
+    issued and processed correctly, i.e. when the CI produced reliable, useful
+    results for the user to review.
+
+    The message contains the following information about a Jenkins job build:
+        - component
+        - DistGit branch built
+        - a list of targets that were attempted to build
+        - result line for each attempted build
+        - final verdict
+        - link to a Jenkins build console log
+    """
+    TEMPLATE = """
+Component:     $component
+Branch:        $branch
+Brew targets:  $targets
+
+Final result:  $final_result
+
+Individual results:
+$individual_results
+
+Debug log:      $debug_log
+
+--
+$project_page
+"""
+
+    def __init__(self, builds, component, branch):
+        self.template = Template(BrewBuildsNotification.TEMPLATE)
+        self.builds = builds
+        self.component = component
+        self.branch = branch
+
+        if "BUILD_URL" in os.environ:
+            self.debug = "%s/console" % os.environ["BUILD_URL"]
+        else:
+            self.debug = "unknown"
+
+        if "PLATFORM_CI_PROJECT" in os.environ:
+            self.project_page = "CI Project page: {0}".format(os.environ["PLATFORM_CI_PROJECT"])
+        else:
+            self.project_page = ""
+
+    def __str__(self):
+        if self.builds.all_successful():
+            final_result = "PASS"
+        else:
+            final_result = "FAIL (%s builds failed)" % self.builds.count_failed()
+
+        individiual_results = IndividualBrewBuildResults(self.builds)
+
+        return self.template.substitute(component=self.component, branch=self.branch, final_result=final_result,
+                                        targets=" ".join(self.builds.targets), individual_results=individiual_results,
+                                        debug_log=self.debug, project_page=self.project_page)

--- a/build-on-push/platform_ci/platform_ci/notifications.py
+++ b/build-on-push/platform_ci/platform_ci/notifications.py
@@ -30,6 +30,8 @@ import textwrap
 
 from string import Template
 
+import platform_ci.config
+
 HEADERS = {"GENERIC_CI": "An error has occurred and the desired action was not performed correctly. "
                          "Please contact the administrators of this CI instance.",
            "CONTACTS_CI": "An error has occurred and no tests were reliably executed. ",
@@ -61,13 +63,15 @@ def create_platform_error_header(header_title=HEADERS["CONTACTS_CI"]):
 
     call_to_action = "Please contact {admins} or file a bug{destination}."
 
-    if "PLATFORM_CI_ADMINS" in os.environ:
-        admins = "{0} ({1})".format(PLATFORM_CI_ADMINS, os.environ["PLATFORM_CI_ADMINS"])
+    config = platform_ci.config.PlatformCIConfig()
+
+    if config.admins:
+        admins = "{0} ({1})".format(PLATFORM_CI_ADMINS, config.admins)
     else:
         admins = PLATFORM_CI_ADMINS
 
-    if "PLATFORM_CI_BUG_DESTINATION" in os.environ:
-        destination = " at {0}".format(os.environ["PLATFORM_CI_BUG_DESTINATION"])
+    if config.bug_destination:
+        destination = " at {0}".format(config.bug_destination)
     else:
         destination = ""
 
@@ -125,8 +129,10 @@ $project_page
         else:
             self.debug = "unknown"
 
-        if "PLATFORM_CI_PROJECT" in os.environ:
-            self.project_page = "CI Project page: {0}".format(os.environ["PLATFORM_CI_PROJECT"])
+        config = platform_ci.config.PlatformCIConfig()
+
+        if config.project_url:
+            self.project_page = "CI Project page: {0}".format(config.project_url)
         else:
             self.project_page = ""
 
@@ -200,8 +206,10 @@ $project_page
         else:
             self.debug = "unknown"
 
-        if "PLATFORM_CI_PROJECT" in os.environ:
-            self.project_page = "CI Project page: {0}".format(os.environ["PLATFORM_CI_PROJECT"])
+        config = platform_ci.config.PlatformCIConfig()
+
+        if config.project_url:
+            self.project_page = "CI Project page: {0}".format(config.project_url)
         else:
             self.project_page = ""
 

--- a/build-on-push/platform_ci/platform_ci/wscript
+++ b/build-on-push/platform_ci/platform_ci/wscript
@@ -1,0 +1,39 @@
+# Copyright 2016 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import glob
+import os.path
+
+
+def pylint_file(ctx, python_file):
+    ctx(rule="pylint --rcfile=%s/.pylint ${SRC} && touch ${TGT}" % ctx.srcnode.abspath(), source=python_file,
+        target="platform_ci/platform_ci/%s.pylint" % python_file)
+
+
+def pep8_file(ctx, python_file):
+    ctx(rule="pep8 --ignore=E501 ${SRC} && touch ${TGT}", source=python_file,
+        target="platform_ci/platform_ci/%s.pep8" % (python_file))
+
+
+def python_static_analysis(ctx):
+    python_files = glob.glob(os.path.join(ctx.path.abspath(), "*.py"))
+    python_files.append(os.path.join(ctx.path.abspath(), "wscript"))
+
+    for python_file in python_files:
+        pylint_file(ctx, os.path.basename(python_file))
+        pep8_file(ctx, os.path.basename(python_file))
+
+
+def build(ctx):
+    python_static_analysis(ctx)

--- a/build-on-push/platform_ci/setup.py
+++ b/build-on-push/platform_ci/setup.py
@@ -1,0 +1,23 @@
+# Copyright 2016 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from distutils.core import setup
+
+setup(name="platform_ci",
+      version="0.1",
+      description="This module contains classes to support Platform CI instance",
+      author="Petr Muller",
+      author_email="muller@redhat.com",
+      url="https://github.com/RHQE/platform-ci",
+      packages=["platform_ci"])

--- a/build-on-push/platform_ci/wscript
+++ b/build-on-push/platform_ci/wscript
@@ -1,0 +1,45 @@
+# Copyright 2016 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import glob
+import os.path
+
+
+def pylint_file(ctx, python_file):
+    ctx(rule="pylint --rcfile=%s/.pylint ${SRC} && touch ${TGT}" % ctx.srcnode.abspath(), source=python_file,
+        target="scripts/platform_ci/%s.pylint" % python_file)
+
+
+def pep8_file(ctx, python_file):
+    ctx(rule="pep8 --ignore=E501 ${SRC} && touch ${TGT}", source=python_file,
+        target="scripts/platform_ci/%s.pep8" % (python_file))
+
+
+def python_static_analysis(ctx):
+    python_files = glob.glob(os.path.join(ctx.path.abspath(), "*.py"))
+    python_files.append(os.path.join(ctx.path.abspath(), "wscript"))
+
+    for python_file in python_files:
+        pylint_file(ctx, os.path.basename(python_file))
+        pep8_file(ctx, os.path.basename(python_file))
+
+
+def python_tests(ctx):
+    ctx(rule="nosetests " + os.path.join(ctx.path.abspath(), "platform_ci"), always=True)
+
+
+def build(ctx):
+    python_static_analysis(ctx)
+    python_tests(ctx)
+    ctx.recurse("platform_ci")

--- a/build-on-push/scripts/ci_commit
+++ b/build-on-push/scripts/ci_commit
@@ -19,8 +19,8 @@ import argparse
 import logging
 import os
 import subprocess
-from platform_ci.distgit import DistGitBranch
-from platform_ci.ci_types import CommitCI
+from platform_ci.distgit import DistGitCommit
+from platform_ci.ci_types import CommitCI, PlatformCISource
 from platform_ci.jenkins import PlatformJenkins
 from platform_ci.brew import BrewBuildAttempts, BuildToCommitterMapping
 import platform_ci.notifications as notifications
@@ -48,7 +48,8 @@ def enable(args):
     jenkins_url = os.environ["JENKINS_URL"]
 
     commit_ci = CommitCI(PlatformJenkins.get_jenkins(jenkins_url, args.templates), args.component)
-    commit_ci.enable(args.slave, args.platform_ci_repo, args.platform_ci_branch)
+    platform_ci_source = PlatformCISource(args.platform_ci_repo, args.platform_ci_branch)
+    commit_ci.enable(args.slave, platform_ci_source)
 
 
 def disable(args):
@@ -94,10 +95,12 @@ def run(args):
 
     logging.info("Building scratch build on branch [%s] of component [%s]", args.branch, args.component)
     jenkins_url = os.environ["JENKINS_URL"]
-    commit_ci = CommitCI(PlatformJenkins.get_jenkins(jenkins_url, args.templates), args.component)
 
-    branch = DistGitBranch(args.branch)
-    commit_ci.consider_build(branch, args.slave, args.platform_ci_repo, args.platform_ci_branch, args.config)
+    platform_ci_source = PlatformCISource(args.platform_ci_repo, args.platform_ci_branch)
+    commit = DistGitCommit(args.commit_hash, args.branch, args.commit_description)
+
+    commit_ci = CommitCI(PlatformJenkins.get_jenkins(jenkins_url, args.templates), args.component)
+    commit_ci.consider_build(commit, args.slave, platform_ci_source, args.config)
 
 
 def build(args):
@@ -195,7 +198,7 @@ def main():
     parser_enable.add_argument("templates", metavar="DIRECTORY")
     parser_enable.add_argument("slave", metavar="SLAVE")
     parser_enable.add_argument("platform_ci_repo", metavar="ACCOUNT", default="RHQE")
-    parser_enable.add_argument("platform_ci_branch", metavar="BRANCH")
+    parser_enable.add_argument("platform_ci_branch", metavar="BRANCH", default="master")
     parser_enable.set_defaults(func=enable)
 
     parser_disable = subparsers.add_parser("disable")
@@ -208,8 +211,10 @@ def main():
     parser_run.add_argument("templates")
     parser_run.add_argument("slave", metavar="SLAVE")
     parser_run.add_argument("platform_ci_repo", metavar="GITHUB_USER", default="RHQE")
-    parser_run.add_argument("platform_ci_branch", metavar="BRANCH")
+    parser_run.add_argument("platform_ci_branch", metavar="BRANCH", default="master")
     parser_run.add_argument("--config", dest="config", metavar="FILE", default=None)
+    parser_run.add_argument("--commit-hash", dest="commit_hash", default=None)
+    parser_run.add_argument("--commit-description", dest="commit_description", default=None)
     parser_run.set_defaults(func=run)
 
     parser_build = subparsers.add_parser("build")

--- a/build-on-push/scripts/ci_commit
+++ b/build-on-push/scripts/ci_commit
@@ -1,0 +1,240 @@
+#!/usr/bin/python
+
+# Copyright 2016 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import argparse
+import logging
+import os
+import subprocess
+from platform_ci.distgit import DistGitBranch
+from platform_ci.ci_types import CommitCI
+from platform_ci.jenkins import PlatformJenkins
+from platform_ci.brew import BrewBuildAttempts, BuildToCommitterMapping
+import platform_ci.notifications as notifications
+
+
+def enable(args):
+    """Enable Build-on-Push CI for a component.
+
+    Create a job, called a *dispatcher*, that is triggered on all new commits
+    in the repository for the component.
+
+    Args:
+        args: An argparse namespace as passed to the program.
+
+        args.component: Component name
+        args.templates: A path to a directory with JJB templates
+        args.slave: A slave name where the jobs should be run
+        args.platform_ci_repo: A GitHub account namespace of the Platform CI
+            repo from which the created jobs will fetch support code.
+        args.platform_ci_branch: A branch name of the Platform CI repo
+            from which the created jobs will fetch support code.
+    """
+    logging.info("Enabling Commit CI for component:  %s", args.component)
+
+    jenkins_url = os.environ["JENKINS_URL"]
+
+    commit_ci = CommitCI(PlatformJenkins.get_jenkins(jenkins_url, args.templates), args.component)
+    commit_ci.enable(args.slave, args.platform_ci_repo, args.platform_ci_branch)
+
+
+def disable(args):
+    """Disable Build-on-Push CI for a component.
+
+    Disable a dispatcher job for a component if it exists. Do nothing
+    if the dispatcher job does not exist.
+
+    Args:
+        args: An argparse namespace as passed to the program.
+
+        args.component: Component name
+    """
+    logging.info("Disabling Commit CI for component: %s", args.component)
+
+    jenkins_url = os.environ["JENKINS_URL"]
+
+    commit_ci = CommitCI(PlatformJenkins.get_jenkins(jenkins_url), args.component)
+    commit_ci.disable()
+
+
+def run(args):
+    """Decide if a branch with new commits should be built, if yes, trigger a job.
+
+    This method implements a procedure done by the dispatcher job.
+
+    Decide if the branch should be build. If yes, trigger the *worker* job if
+    it exists. If it does not, create the worker job first, then trigger it.
+
+    Args:
+        args: An argparse namespace as passed to the program.
+
+        args.component: Component name
+        args.branch: A name of a component repository branch with new commits
+        args.templates: A path to a directory with JJB templates
+        args.slave: A slave name where the jobs should be run
+        args.platform_ci_branch: A branch name of the Platform CI repo
+            from which the created builds will fetch support code.
+        args.platform_ci_repo: A GitHub user whose Platform CI fort
+            will be used to getch the support code.
+        args.config: A path of the config file, if present in the branch.
+    """
+
+    logging.info("Building scratch build on branch [%s] of component [%s]", args.branch, args.component)
+    jenkins_url = os.environ["JENKINS_URL"]
+    commit_ci = CommitCI(PlatformJenkins.get_jenkins(jenkins_url, args.templates), args.component)
+
+    branch = DistGitBranch(args.branch)
+    commit_ci.consider_build(branch, args.slave, args.platform_ci_repo, args.platform_ci_branch, args.config)
+
+
+def build(args):
+    """Issue a scratch build request on a given branch.
+
+    This method implements the sequence done by *worker* job.
+
+    Check out the branch, then issue a Brew scratch build from the code present
+    in the branch.
+
+    Args:
+        args: An argparse namespace as passed to the program.
+
+        args.component: Component name
+        args.branch: A name of a component repository branch with new commits
+        args.addresses: A file to which the email addresses related
+            to the issued build will be written for later matching
+        args.targets: A list of Brew targets for which builds will be attempted.
+        args.report: A path to a file where the notification message body will
+            be written.
+    """
+    logging.info("Checking out branch %s of git repository %s", args.branch, args.component)
+
+    if args.addresses:
+        addresses_file = open(args.addresses, "w")
+
+    cwd = os.getcwd()
+    os.chdir(args.component)
+
+    subprocess.check_call(["git", "branch", "--set-upstream", args.branch, "origin/{0}".format(args.branch)])
+
+    if args.addresses:
+        command = ["git", "--no-pager", "show", "-s", "--format=%ce", "HEAD"]
+        git_commiter_query = subprocess.Popen(command, stdout=subprocess.PIPE)
+        author = git_commiter_query.communicate()[0].strip()
+        git_commiter_query.wait()
+        if git_commiter_query.returncode != 0:
+            raise subprocess.CalledProcessError(git_commiter_query.returncode, command)
+        addresses_file.write(author)
+        addresses_file.close()
+
+    builds = BrewBuildAttempts(args.targets, cwd)
+    builds.execute()
+    builds.wait()
+
+    os.chdir(cwd)
+    if args.report:
+        logging.info("Creating an email notification file")
+        notification = notifications.BrewBuildsNotification(builds, args.component, args.branch)
+        with open(args.report, "w") as report:
+            report.write(str(notification))
+
+    if builds.all_successful():
+        for brew_build in builds.all():
+            mapping = BuildToCommitterMapping(brew_build.task_id, author)
+            mapping.save()
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+def create_error_email_notification(args, error_header, error_message):
+    """Create a error notification email body.
+
+    Create a notification message and write it into a file. The notification
+    message is customized with a header (that usually describes a class of
+    possible errors to the user) and an error message (the specific failure
+    that happened in this case.
+
+    Args:
+        args: An argparse namespace as passed to the program.
+        error_header: A paragraph explaining this class of errors to the user
+        error_message: A specific message about that exactly happened.
+
+        args.report: A path to a (writable) file where the message will be written
+        args.component: Component name
+        args.branch: A name of a component repository branch with new commits
+        args.targets: A list of Brew targets for which builds were attempted
+    """
+    if args.report:
+        notification = notifications.BrewBuildsErrorNotification(error_header, error_message, args.component,
+                                                                 args.branch, args.targets)
+        with open(args.report, "w") as report:
+            report.write(str(notification))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--report", default=None)
+
+    subparsers = parser.add_subparsers()
+
+    parser_enable = subparsers.add_parser("enable")
+    parser_enable.add_argument("component")
+    parser_enable.add_argument("templates", metavar="DIRECTORY")
+    parser_enable.add_argument("slave", metavar="SLAVE")
+    parser_enable.add_argument("platform_ci_repo", metavar="ACCOUNT", default="RHQE")
+    parser_enable.add_argument("platform_ci_branch", metavar="BRANCH")
+    parser_enable.set_defaults(func=enable)
+
+    parser_disable = subparsers.add_parser("disable")
+    parser_disable.add_argument("component")
+    parser_disable.set_defaults(func=disable)
+
+    parser_run = subparsers.add_parser("run")
+    parser_run.add_argument("component")
+    parser_run.add_argument("branch")
+    parser_run.add_argument("templates")
+    parser_run.add_argument("slave", metavar="SLAVE")
+    parser_run.add_argument("platform_ci_repo", metavar="GITHUB_USER", default="RHQE")
+    parser_run.add_argument("platform_ci_branch", metavar="BRANCH")
+    parser_run.add_argument("--config", dest="config", metavar="FILE", default=None)
+    parser_run.set_defaults(func=run)
+
+    parser_build = subparsers.add_parser("build")
+    parser_build.add_argument("component")
+    parser_build.add_argument("branch")
+    parser_build.add_argument("targets", nargs="+")
+    parser_build.add_argument("--committer-emails", dest="addresses", metavar="FILE", default=None)
+    parser_build.set_defaults(func=build)
+
+    logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
+
+    args = parser.parse_args()
+    cwd = os.getcwd()
+
+    try:
+        args.func(args)
+    except notifications.BaseCIException as exc:
+        os.chdir(cwd)
+        create_error_email_notification(args, exc.header, str(exc))
+        raise
+    except Exception as exc:
+        os.chdir(cwd)
+        create_error_email_notification(args, str(exc), notifications.create_platform_error_header())
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/build-on-push/scripts/ci_commit
+++ b/build-on-push/scripts/ci_commit
@@ -90,17 +90,26 @@ def run(args):
             from which the created builds will fetch support code.
         args.platform_ci_repo: A GitHub user whose Platform CI fort
             will be used to getch the support code.
-        args.config: A path of the config file, if present in the branch.
+        args.config: A name of a file that is searched in a branch. If such file
+            is present in a branch, the branch will be built as if it were
+            a staging branch.
     """
 
     logging.info("Building scratch build on branch [%s] of component [%s]", args.branch, args.component)
     jenkins_url = os.environ["JENKINS_URL"]
 
+    config_file_path = os.path.join(args.component, args.config)
+
+    if os.path.isfile(config_file_path):
+        config_file = config_file_path
+    else:
+        config_file = None
+
     platform_ci_source = PlatformCISource(args.platform_ci_repo, args.platform_ci_branch)
     commit = DistGitCommit(args.commit_hash, args.branch, args.commit_description)
 
     commit_ci = CommitCI(PlatformJenkins.get_jenkins(jenkins_url, args.templates), args.component)
-    commit_ci.consider_build(commit, args.slave, platform_ci_source, args.config)
+    commit_ci.consider_build(commit, args.slave, platform_ci_source, config_file)
 
 
 def build(args):
@@ -212,7 +221,7 @@ def main():
     parser_run.add_argument("slave", metavar="SLAVE")
     parser_run.add_argument("platform_ci_repo", metavar="GITHUB_USER", default="RHQE")
     parser_run.add_argument("platform_ci_branch", metavar="BRANCH", default="master")
-    parser_run.add_argument("--config", dest="config", metavar="FILE", default=None)
+    parser_run.add_argument("--config", dest="config", metavar="FILE", default="ci.yaml")
     parser_run.add_argument("--commit-hash", dest="commit_hash", default=None)
     parser_run.add_argument("--commit-description", dest="commit_description", default=None)
     parser_run.set_defaults(func=run)

--- a/build-on-push/scripts/functions
+++ b/build-on-push/scripts/functions
@@ -54,3 +54,12 @@ set_current_build_description(){
     echo "Probably not running in a Jenkins build. Build description cannot be updated" >&2
   fi
 }
+
+set_current_build_display_name() {
+  if [ -n "$JOB_NAME" ] && [ -n "$BUILD_NUMBER" ]
+  then
+    jenkins_cli set-build-display-name "$JOB_NAME" "$BUILD_NUMBER" "$1"
+  else
+    echo "Probably not running in a Jenkins build. Build display name cannot be updated" >&2
+  fi
+}

--- a/build-on-push/scripts/functions
+++ b/build-on-push/scripts/functions
@@ -17,9 +17,9 @@
 # Common code used in the bash Jenkins job build phases
 
 log_header(){
-    echo
-    echo "======================== $1 ================================="
-    echo
+  echo
+  echo "======================== $1 ================================="
+  echo
 }
 
 jenkins_cli(){
@@ -35,8 +35,8 @@ jenkins_cli(){
 # Check if the supplied name is a valid component name, by checking if
 # it has a valid dist-git entry.
 component_sane(){
-	echo "Checking if $1 is a valid parameter name"
-	if [ -n "$BOP_DIST_GIT_URL" ]; then
+  echo "Checking if $1 is a valid parameter name"
+  if [ -n "$BOP_DIST_GIT_URL" ]; then
     echo "Looking at $BOP_DIST_GIT_URL/$1"
     git ls-remote "$BOP_DIST_GIT_URL/$1" >/dev/null
     return $?

--- a/build-on-push/scripts/functions
+++ b/build-on-push/scripts/functions
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Copyright 2016 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Common code used in the bash Jenkins job build phases
+
+log_header(){
+    echo
+    echo "======================== $1 ================================="
+    echo
+}
+
+jenkins_cli(){
+  if [ -n "$BOP_JENKINS_CLI" ]; then
+    $BOP_JENKINS_CLI -noCertificateCheck -s "$JENKINS_URL" "${@}"
+    return $?
+  else
+    echo "BOP_JENKINS_CLI not set: cannot use Jenkins CLI"
+    return 1
+  fi
+}
+
+# Check if the supplied name is a valid component name, by checking if
+# it has a valid dist-git entry.
+component_sane(){
+	echo "Checking if $1 is a valid parameter name"
+	if [ -n "$BOP_DIST_GIT_URL" ]; then
+    echo "Looking at $BOP_DIST_GIT_URL/$1"
+    git ls-remote "$BOP_DIST_GIT_URL/$1" >/dev/null
+    return $?
+  else
+    echo "BOP_DIST_GIT_URL not set: could not verify component sanity"
+    return 1
+  fi
+}
+
+set_current_build_description(){
+  if [ -n "$JOB_NAME" ] && [ -n "$BUILD_NUMBER" ]
+  then
+    jenkins_cli set-build-description "$JOB_NAME" "$BUILD_NUMBER" "$1"
+  else
+    echo "Probably not running in a Jenkins build. Build description cannot be updated" >&2
+  fi
+}

--- a/build-on-push/scripts/job-commit-dispatcher.sh
+++ b/build-on-push/scripts/job-commit-dispatcher.sh
@@ -44,7 +44,8 @@ echo "Job will run on slave:  $SLAVE"
 echo "Platform CI repo:       $PLATFORM_CI_REPO"
 echo "Platform CI branch:     $PLATFORM_CI_BRANCH"
 
-set_current_build_description "$SHORT_GIT_BRANCH"
+set_current_build_description "branch=$SHORT_GIT_BRANCH commit=$GIT_COMMIT"
+set_current_build_display_name "$SHORT_GIT_BRANCH:$GIT_COMMIT"
 
 log_header "Checking ci.yaml file"
 

--- a/build-on-push/scripts/job-commit-dispatcher.sh
+++ b/build-on-push/scripts/job-commit-dispatcher.sh
@@ -1,0 +1,63 @@
+#!/bin/bash -e
+
+# Copyright 2016 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+PLATFORM_CI_HOME=${PLATFORM_CI_HOME:-./platform-ci}
+
+if [ ! -d "$PLATFORM_CI_HOME" ]
+then
+  echo "Cannot find Platform CI code in '$PLATFORM_CI_HOME'" >&2
+  echo "Exiting." >&2
+  exit 1
+fi
+
+BOP_HOME="$PLATFORM_CI_HOME/build-on-push"
+
+. "$BOP_HOME/scripts/functions"
+
+log_header "Extracting git branch name"
+
+COMPONENT="$1"
+GIT_BRANCH="$2"
+SLAVE="$NODE_NAME"
+SHORT_GIT_BRANCH=$GIT_BRANCH
+PLATFORM_CI_REPO="$3"
+PLATFORM_CI_BRANCH="$4"
+
+[[ "$GIT_BRANCH" =~ ^origin/ ]] && SHORT_GIT_BRANCH=$( cut -c '8-' <<< "$GIT_BRANCH" )
+
+echo "Branch name:            $GIT_BRANCH"
+echo "Short branch name:      $SHORT_GIT_BRANCH"
+echo "Job will run on slave:  $SLAVE"
+echo "Platform CI repo:       $PLATFORM_CI_REPO"
+echo "Platform CI branch:     $PLATFORM_CI_BRANCH"
+
+set_current_build_description "$SHORT_GIT_BRANCH"
+
+log_header "Checking ci.yaml file"
+
+if [ ! -e "$COMPONENT/ci.yaml" ]
+then
+  echo "File 'ci.yaml' not found"
+  CONFIG_FILE_PARAM=""
+else
+  echo "File 'ci.yaml' found"
+  CONFIG_FILE_PARAM="--config=$COMPONENT/ci.yaml"
+fi
+
+log_header "Triggering build job"
+
+eval ci_commit run "$COMPONENT" "$SHORT_GIT_BRANCH" "platform-ci/build-on-push/jjb" "$SLAVE" "$PLATFORM_CI_REPO" \
+    "$PLATFORM_CI_BRANCH" "$CONFIG_FILE_PARAM"

--- a/build-on-push/scripts/job-commit-dispatcher.sh
+++ b/build-on-push/scripts/job-commit-dispatcher.sh
@@ -54,5 +54,5 @@ set_current_build_display_name "$SHORT_GIT_BRANCH:$SHORT_GIT_COMMIT"
 
 log_header "Triggering build job"
 
-ci_commit run "$COMPONENT" "$SHORT_GIT_BRANCH" "platform-ci/build-on-push/jjb" "$SLAVE" "$PLATFORM_CI_REPO" \
-    "$PLATFORM_CI_BRANCH" --commit-hash="$SHORT_GIT_COMMIT" --commit-description="$COMMIT_DESCRIPTION"
+ci_commit run "$COMPONENT" "$SHORT_GIT_BRANCH" "$BOP_HOME/jjb" "$SLAVE" "$PLATFORM_CI_REPO" "$PLATFORM_CI_BRANCH" \
+    --commit-hash="$SHORT_GIT_COMMIT" --commit-description="$COMMIT_DESCRIPTION"

--- a/build-on-push/scripts/job-commit-dispatcher.sh
+++ b/build-on-push/scripts/job-commit-dispatcher.sh
@@ -52,19 +52,7 @@ echo "Platform CI branch:     $PLATFORM_CI_BRANCH"
 set_current_build_description "branch=$SHORT_GIT_BRANCH commit=$SHORT_GIT_COMMIT<br/>$COMMIT_DESCRIPTION_HTML"
 set_current_build_display_name "$SHORT_GIT_BRANCH:$SHORT_GIT_COMMIT"
 
-log_header "Checking ci.yaml file"
-
-if [ ! -e "$COMPONENT/ci.yaml" ]
-then
-  echo "File 'ci.yaml' not found"
-  CONFIG_FILE_PARAM=""
-else
-  echo "File 'ci.yaml' found"
-  CONFIG_FILE_PARAM="--config=$COMPONENT/ci.yaml"
-fi
-
 log_header "Triggering build job"
 
-eval ci_commit run "$COMPONENT" "$SHORT_GIT_BRANCH" "platform-ci/build-on-push/jjb" "$SLAVE" "$PLATFORM_CI_REPO" \
-    "$PLATFORM_CI_BRANCH" "$CONFIG_FILE_PARAM" --commit-hash="$SHORT_GIT_COMMIT" \
-    --commit-description="$COMMIT_DESCRIPTION"
+ci_commit run "$COMPONENT" "$SHORT_GIT_BRANCH" "platform-ci/build-on-push/jjb" "$SLAVE" "$PLATFORM_CI_REPO" \
+    "$PLATFORM_CI_BRANCH" --commit-hash="$SHORT_GIT_COMMIT" --commit-description="$COMMIT_DESCRIPTION"

--- a/build-on-push/scripts/job-commit-worker.sh
+++ b/build-on-push/scripts/job-commit-worker.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Copyright 2016 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+PROJECT="$1"
+BRANCH="$2"
+
+. platform-ci/scripts/functions
+
+rm -f "$WORKSPACE/notification-email.txt" "$WORKSPACE/addresses.txt"
+
+if ! ci_commit --report notification-email.txt build "$PROJECT" "$BRANCH" $BREW_TARGETS --committer-emails=addresses.txt
+then
+	exit 1
+fi

--- a/build-on-push/scripts/job-commit-worker.sh
+++ b/build-on-push/scripts/job-commit-worker.sh
@@ -14,10 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+PLATFORM_CI_HOME=${PLATFORM_CI_HOME:-./platform-ci}
+BOP_HOME="$PLATFORM_CI_HOME/build-on-push"
+
 PROJECT="$1"
 BRANCH="$2"
 
-. platform-ci/scripts/functions
+
+. "$BOP_HOME/scripts/functions"
 
 rm -f "$WORKSPACE/notification-email.txt" "$WORKSPACE/addresses.txt"
 

--- a/build-on-push/scripts/job-platform-component-setup.sh
+++ b/build-on-push/scripts/job-platform-component-setup.sh
@@ -1,0 +1,69 @@
+#!/bin/bash -e
+
+# Copyright 2016 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Controls the presence of the component triggers on the Jenkins master.
+
+PLATFORM_CI_HOME=${PLATFORM_CI_HOME:-./platform-ci}
+
+if [ ! -d "$PLATFORM_CI_HOME" ]
+then
+  echo "Cannot find Platform CI code in '$PLATFORM_CI_HOME'" >&2
+  echo "Exiting." >&2
+  exit 1
+fi
+
+BOP_HOME="$PLATFORM_CI_HOME/build-on-push"
+
+. "$BOP_HOME/scripts/functions"
+
+log_header "One-time CI setup"
+
+COMPONENT="$1"
+BUILD_ON_COMMIT="$2"
+SLAVE="$3"
+PLATFORM_CI_REPO="$4"
+PLATFORM_CI_BRANCH="$5"
+
+echo "Setting CI for component:       $COMPONENT"
+echo "Jobs will run on slave:         $SLAVE"
+echo "BUILD_ON_COMMIT will be set to: $BUILD_ON_COMMIT"
+echo "Platform CI repo:               $PLATFORM_CI_REPO"
+echo "Platform CI branch:             $PLATFORM_CI_BRANCH"
+
+set_current_build_description "$COMPONENT BUILD_ON_COMMIT=$BUILD_ON_COMMIT"
+
+log_header "Checking component sanity"
+
+if ! component_sane "$COMPONENT"; then
+  echo "Component '$COMPONENT' does not seem to be valid component name"
+  exit 1
+else
+  echo "Component '$COMPONENT' is sane"
+fi
+
+ci_process() {
+  local COMMAND="$1"
+  local CI="$2"
+  local COMPONENT="$3"
+
+  log_header "Setting $CI"
+  if [ "$COMMAND" != "do not modify current settings" ];  then
+	eval "$BOP_HOME/scripts/ci_$CI" "$COMMAND" "$COMPONENT" "$BOP_HOME/jjb" "$SLAVE" "$PLATFORM_CI_REPO" \
+	   "$PLATFORM_CI_BRANCH"
+  fi
+}
+
+ci_process "$BUILD_ON_COMMIT" commit "$COMPONENT"

--- a/build-on-push/scripts/wscript
+++ b/build-on-push/scripts/wscript
@@ -1,0 +1,67 @@
+# Copyright 2016 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import os
+import glob
+
+
+def configure(ctx):
+    ctx.find_program("shellcheck")
+    ctx.env.env = dict(os.environ)
+    ctx.env.env['PYTHONPATH'] = os.pathsep.join(sys.path + [os.path.join(ctx.srcnode.abspath(), "platform_ci")])
+
+
+def pylint_file(ctx, python_file):
+    ctx(rule="pylint --rcfile=%s/.pylint ${SRC} && touch ${TGT}" % ctx.srcnode.abspath(), source=python_file,
+        target="scripts/%s.pylint" % python_file)
+
+
+def pep8_file(ctx, python_file):
+    ctx(rule="pep8 --ignore=E501 ${SRC} && touch ${TGT}", source=python_file, target="scripts/%s.pep8" % (python_file))
+
+
+def python_static_analysis(ctx):
+    python_files = glob.glob(os.path.join(ctx.path.abspath(), "*.py"))
+    python_files.append(os.path.join(ctx.path.abspath(), "wscript"))
+    pyfiles = ("ci_commit",)
+    python_files.extend([os.path.join(ctx.path.abspath(), pyfile) for pyfile in pyfiles])
+
+    for python_file in python_files:
+        pylint_file(ctx, os.path.basename(python_file))
+        pep8_file(ctx, os.path.basename(python_file))
+
+
+def shellcheck_file(ctx, shell_file):
+    excludes = {"job-platform-component-setup.sh": "SC2086,SC2089,SC2090"}
+    excludes = {"job-commit-worker.sh": "SC2086"}
+    exclude = ""
+    if shell_file in excludes:
+        exclude = "--exclude=%s" % (excludes[shell_file])
+
+    ctx(rule="shellcheck %s ${SRC} && touch ${TGT}" % exclude, source=shell_file,
+        target="scripts/%s.shellcheck" % shell_file)
+
+
+def shell_static_analysis(ctx):
+    shell_files = ["functions", "job-platform-component-setup.sh", "job-commit-dispatcher.sh", "job-commit-worker.sh"]
+    shell_file_paths = [os.path.join(ctx.path.abspath(), shell_file) for shell_file in shell_files]
+
+    for shell_file in shell_file_paths:
+        shellcheck_file(ctx, os.path.basename(shell_file))
+
+
+def build(ctx):
+    python_static_analysis(ctx)
+    shell_static_analysis(ctx)

--- a/build-on-push/wscript
+++ b/build-on-push/wscript
@@ -1,0 +1,63 @@
+# Copyright 2016 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os.path
+import glob
+
+
+top = "."
+out = "build"
+
+
+def options(ctx):
+    ctx.load("python")
+
+
+def configure(ctx):
+    ctx.find_program("jenkins-jobs")
+    ctx.find_program("pep8")
+    ctx.find_program("pylint")
+    ctx.find_program("shellcheck")
+    ctx.load("python")
+    ctx.check_python_module("mock")
+    ctx.check_python_module("koji")
+    ctx.find_program("nosetests")
+
+    ctx.recurse("scripts")
+    ctx.recurse("jjb")
+
+
+def build(ctx):
+    python_static_analysis(ctx)
+    ctx.recurse("scripts")
+    ctx.recurse("jjb")
+    ctx.recurse("platform_ci")
+
+
+def pylint_file(ctx, python_file):
+    ctx(rule="pylint --rcfile=%s/.pylint ${SRC} && touch ${TGT}" % ctx.srcnode.abspath(), source=python_file,
+        target="%s.pylint" % python_file)
+
+
+def pep8_file(ctx, python_file):
+    ctx(rule="pep8 --ignore=E501 ${SRC} && touch ${TGT}", source=python_file, target="%s.pep8" % python_file)
+
+
+def python_static_analysis(ctx):
+    python_files = glob.glob(os.path.join(ctx.srcnode.abspath(), "*.py"))
+    python_files.append("wscript")
+
+    for python_file in python_files:
+        pylint_file(ctx, python_file)
+        pep8_file(ctx, python_file)


### PR DESCRIPTION
This PR brings the Build-on-Push functionality (already used and tested on BaseOS CI instance). It allows, after one-time setup per component, watching changes in the component's DistGit repository and attempting to build  a testing scratch build for the "interesting" branches (either by naming convention, so called "staging" branches, or via presence of a small YAML config file, similar to Travis CI). There exists a single job per branch, so that build results of code from separate branches are separate too. These per-branch jobs are created automatically when first needed, without any action needed else than the developer first pushing into such branch.
### How to test (static analysis and unit tests):

Tests and static analysis driver is provided in the PR. The tests are driven by 'waf'. To launch the tests, you will need the following dependencies installed:
- Jenkins Job Builder
- pep8 (python style checker)
- pylint (python static analyser)
- shellcheck (shell static analyser)
- Python 'mock' package
- Python 'koji' package
- nosetests (python unit test driver)

Then in the 'build-on-push' directory. run `waf configure` (which will fail if you do not have all dependencies installed)

> $ waf configure
> Setting top to                           : /home/pmuller/Projects/RedHat/CI/platform-ci-gh/build-on-push 
> Setting out to                           : /home/pmuller/Projects/RedHat/CI/platform-ci-gh/build-on-push/build 
> Checking for program 'jenkins-jobs'      : /usr/bin/jenkins-jobs 
> Checking for program 'pep8'              : /usr/bin/pep8 
> Checking for program 'pylint'            : /home/pmuller/Projects/RedHat/CI/platform-ci-gh/build-on-push/venv-platform/bin/pylint 
> Checking for program 'shellcheck'        : /usr/bin/shellcheck 
> Checking for program 'python'            : /usr/bin/python2 
> Checking for python module 'mock'        : 1.3.0 
> Checking for python module 'koji'        : ok 
> Checking for program 'nosetests'         : /usr/bin/nosetests 
> Checking for program 'shellcheck'        : /usr/bin/shellcheck 
> 'configure' finished successfully (0.276s)

Then you can run the tests via `waf build`:

> $ waf build
> Waf: Entering directory `/home/pmuller/Projects/RedHat/CI/platform-ci-gh/build-on-push/build'
> [ 2/46] Compiling wscript
> [ 5/46] Compiling scripts/ci_commit
> ...
### How to test (end-to-end)

Follow the User doc: https://docs.engineering.redhat.com/x/kY1GAg
### More information about Build-on-Push implementation

https://docs.engineering.redhat.com/x/iI1GAg
### Limitations
- Only a subset of product branches are now monitored and built (mostly RHEL and some collections)
- DistGit is polled, bringing problems with a) scalability b) notifications (we do not know who actually pushed the changes)
- Builds issued by Build-on-Push CI are owned by the machine account (not any human): any further testing of the created builds, which will ask Brew for build issue will get this machine owner
- Only x86_64 builds are done
