### PR TITLE
BoP: Build scratch builds for all architectures

### DIFF
--- a/build-on-push/platform_ci/platform_ci/brew.py
+++ b/build-on-push/platform_ci/platform_ci/brew.py
@@ -89,8 +89,8 @@ class BrewBuildAttempt(object):
         """
         logging.info("Building for target [%s]", self.target)
         self._logfile = open(self.logfile_path, "w")
-        self._execution = subprocess.Popen(["rhpkg", "build", "--scratch", "--skip-nvr-check", "--target", self.target,
-                                            "--arches", "x86_64"], stdout=self._logfile, stderr=self._logfile)
+        self._execution = subprocess.Popen(["rhpkg", "build", "--scratch", "--skip-nvr-check", "--target", self.target],
+                                           stdout=self._logfile, stderr=self._logfile)
 
     def wait(self):
         """Blocks until the build request is finished.

--- a/build-on-push/platform_ci/platform_ci/brew_test.py
+++ b/build-on-push/platform_ci/platform_ci/brew_test.py
@@ -54,7 +54,7 @@ class BrewBuildAttemptTest(unittest.TestCase):
         assert mock_open.call_args[0][0] == self.bba.logfile_path
         assert mock_popen.called
         assert mock_popen.call_args[0][0] == ["rhpkg", "build", "--scratch", "--skip-nvr-check", "--target",
-                                              BrewBuildAttemptTest.TEST_TARGET, "--arches", "x86_64"]
+                                              BrewBuildAttemptTest.TEST_TARGET]
 
     # pylint: disable=protected-access
     def wait_success_test(self):


### PR DESCRIPTION
Previously the scratch builds issues by BoP jobs were limited to x86_64. Engineering asks for all architectures to be built.
