### PR TITLE
BoP: Remove arch limitation from job description

### DIFF
--- a/build-on-push/jjb/platform-commit.yaml
+++ b/build-on-push/jjb/platform-commit.yaml
@@ -95,7 +95,7 @@
 
       <p>The build is issued via the following command:</p>
 
-      <p>$ rhpkg build --scratch --skip-nvr-check --target TARGET --arches x86_64</p>
+      <p>$ rhpkg build --scratch --skip-nvr-check --target TARGET</p>
 
       <p><strong>Triggers:</strong> nothing<br>
       <strong>Triggered by:</strong> {dispatcher-link}<br>


### PR DESCRIPTION
Since PR#26 we are now building for all architectures in BoP jobs, but
the job description still mentioned the build is limited to x86_64. This
commit removes that mention.
