### PR TITLE
BoP: Address new branch and target namings

### DIFF
--- a/build-on-push/platform_ci/platform_ci/commit_ci_test.py
+++ b/build-on-push/platform_ci/platform_ci/commit_ci_test.py
@@ -59,7 +59,7 @@ class CommitCITest(unittest.TestCase):
     TEST_BRANCH = "test-branch"
     TEST_CONFIG_FILE = "/file/to/path"
     TEST_STAGING_BRANCH = "staging-rhel-6"
-    TEST_STAGING_TARGET = "rhel-6-staging-candidate"
+    TEST_STAGING_TARGET = "staging-rhel-6-candidate"
     TEST_SLAVE = "team-slave"
     TEST_PLATFORM_CI_BRANCH = "test-branch"
     TEST_GITHUB_USER = "RHQE"

--- a/build-on-push/platform_ci/platform_ci/commit_ci_test.py
+++ b/build-on-push/platform_ci/platform_ci/commit_ci_test.py
@@ -58,8 +58,8 @@ class CommitCITest(unittest.TestCase):
     TEST_TARGETS = ["test-1-target", "test-2-target"]
     TEST_BRANCH = "test-branch"
     TEST_CONFIG_FILE = "/file/to/path"
-    TEST_STAGING_BRANCH = "rhel-6.7-staging"
-    TEST_STAGING_TARGET = "rhel-6.7-candidate"
+    TEST_STAGING_BRANCH = "staging-rhel-6"
+    TEST_STAGING_TARGET = "rhel-6-staging-candidate"
     TEST_SLAVE = "team-slave"
     TEST_PLATFORM_CI_BRANCH = "test-branch"
     TEST_GITHUB_USER = "RHQE"

--- a/build-on-push/platform_ci/platform_ci/distgit.py
+++ b/build-on-push/platform_ci/platform_ci/distgit.py
@@ -69,7 +69,7 @@ class DistGitBranch(object):
 
         Returns: A name of the Brew target associated with the branch name
 
-        Example: DistGitBranch("staging-rhel-7").staging_target -> "rhel-7-staging-candidate"
+        Example: DistGitBranch("staging-rhel-7").staging_target -> "staging-rhel-7-candidate"
         """
         if self.is_staging():
             # Use just the staging branch name match
@@ -77,7 +77,7 @@ class DistGitBranch(object):
 
             # TODO: if the staging branch will be e.g. "rhel-6-staging", the target would be determined incorrectly
             # We would have to get the latest RHEL-6 target and use that.
-            return "{0}-staging-candidate".format(staging_branch_base)
+            return "staging-{0}-candidate".format(staging_branch_base)
         elif self.is_standard():
             # Use just the staging branch name match
             standard_branch_base = DistGitBranch.STANDARD_BRANCH_REGEXP.match(self.name).group('st_branch')

--- a/build-on-push/platform_ci/platform_ci/distgit.py
+++ b/build-on-push/platform_ci/platform_ci/distgit.py
@@ -43,10 +43,10 @@ class DistGitBranch(object):
     STANDARD_BRANCH_REGEXP_PATTERN = r'(?P<st_branch>((extras-)|(rhscl-\d\.\d-rh-\w+?-))?rhel-\d(\.\d)?)$'
 
     # Staging branch examples:
-    #   - Proper staging branches: rhel-7.3-staging, extras-rhel-7.2-staging
-    #   - Private staging branches: private-pmuller-rhel-7.3-staging-bz1234567
-    #                               private-pmuller-extras-rhel-7.2-staging
-    STAGING_BRANCH_REGEXP_PATTERN = r'(?P<st_branch>((extras-)|(rhscl-\d\.\d-rh-\w+?-))?rhel-\d(\.\d)?-staging)'
+    #   - Proper staging branches: staging-rhel-7, staging-extras-rhel-7
+    #   - Private staging branches: private-pmuller-staging-rhel-7-bz1234567
+    #                               private-pmuller-staging-extras-rhel-7
+    STAGING_BRANCH_REGEXP_PATTERN = r'staging-(?P<st_branch>((extras-)|(rhscl-\d\.\d-rh-\w+?-))?rhel-\d)'
 
     STANDARD_BRANCH_REGEXP = re.compile(STANDARD_BRANCH_REGEXP_PATTERN)
 
@@ -69,7 +69,7 @@ class DistGitBranch(object):
 
         Returns: A name of the Brew target associated with the branch name
 
-        Example: DistGitBranch("rhel-7.3-staging").staging_target -> "rhel-7.3-candidate"
+        Example: DistGitBranch("staging-rhel-7").staging_target -> "rhel-7-staging-candidate"
         """
         if self.is_staging():
             # Use just the staging branch name match
@@ -77,7 +77,7 @@ class DistGitBranch(object):
 
             # TODO: if the staging branch will be e.g. "rhel-6-staging", the target would be determined incorrectly
             # We would have to get the latest RHEL-6 target and use that.
-            return staging_branch_base.replace("staging", "candidate")
+            return "{0}-staging-candidate".format(staging_branch_base)
         elif self.is_standard():
             # Use just the staging branch name match
             standard_branch_base = DistGitBranch.STANDARD_BRANCH_REGEXP.match(self.name).group('st_branch')
@@ -101,8 +101,8 @@ class DistGitBranch(object):
 
         Examples:
             standard: rhel-6.8
-            staging: rhel-6.8-staging
-            private staging: private-<anything->rhel-6.8-staging<-anything>
+            staging: staging-rhel-6
+            private staging: private-<anything->staging-rhel-6<-anything>
             private: john-feature-branch-bz123321
 
         Returns:

--- a/build-on-push/platform_ci/platform_ci/distgit_test.py
+++ b/build-on-push/platform_ci/platform_ci/distgit_test.py
@@ -21,11 +21,11 @@ from platform_ci.distgit import DistGitBranch, DistGitBranchException
 
 
 class DistGitBranchTest(unittest.TestCase):
-    STAGING = {"branch": "staging-rhel-7", "target": "rhel-7-staging-candidate"}
+    STAGING = {"branch": "staging-rhel-7", "target": "staging-rhel-7-candidate"}
     PRIVATE = {"branch": "private-pmuller-branch", "target": None}
     STANDARD = {"branch": "rhel-7.2", "target": "rhel-7.2-candidate"}
     EXTRAS_STANDARD = {"branch": "extras-rhel-7.2", "target": "extras-rhel-7.2-candidate"}
-    EXTRAS_STAGING = {"branch": "staging-extras-rhel-7", "target": "extras-rhel-7-staging-candidate"}
+    EXTRAS_STAGING = {"branch": "staging-extras-rhel-7", "target": "staging-extras-rhel-7-candidate"}
 
     def setUp(self):
         self.staging_branch = DistGitBranch(DistGitBranchTest.STAGING["branch"])
@@ -77,7 +77,7 @@ class DistGitBranchTest(unittest.TestCase):
         ]
 
         testing_branches = ["staging-{0}".format(base) for base in testing_bases]
-        testing_targets = ["{0}-staging-candidate".format(base) for base in testing_bases]
+        testing_targets = ["staging-{0}-candidate".format(base) for base in testing_bases]
 
         for branch, target in zip(testing_branches, testing_targets):
             obj = DistGitBranch(branch)
@@ -91,13 +91,13 @@ class DistGitBranchTest(unittest.TestCase):
         Tests for parsing private staging branches for RHSCL and determining the correct build target
         """
         testing_data = [
-            ('private-johnfoo-staging-rhscl-2.1-rh-ruby22-rhel-6', 'rhscl-2.1-rh-ruby22-rhel-6-staging-candidate'),
+            ('private-johnfoo-staging-rhscl-2.1-rh-ruby22-rhel-6', 'staging-rhscl-2.1-rh-ruby22-rhel-6-candidate'),
             ('private-johnfoo-staging-rhscl-2.1-rh-ruby22-rhel-7-BZ123456',
-             'rhscl-2.1-rh-ruby22-rhel-7-staging-candidate'),
+             'staging-rhscl-2.1-rh-ruby22-rhel-7-candidate'),
             ('private-staging-rhscl-2.1-rh-mariadb100-rhel-6-BZ654321',
-             'rhscl-2.1-rh-mariadb100-rhel-6-staging-candidate'),
+             'staging-rhscl-2.1-rh-mariadb100-rhel-6-candidate'),
             ('private-jo-fo-staging-rhscl-2.1-rh-mariadb100-rhel-7-bar-baz',
-             'rhscl-2.1-rh-mariadb100-rhel-7-staging-candidate')
+             'staging-rhscl-2.1-rh-mariadb100-rhel-7-candidate')
         ]
 
         for branch, target in testing_data:
@@ -112,14 +112,14 @@ class DistGitBranchTest(unittest.TestCase):
         Tests for parsing private staging branches for RHEL components and determining the correct build target
         """
         testing_data = [
-            ('private-johnfoo-staging-rhel-7', 'rhel-7-staging-candidate'),
-            ('private-johnfoo-staging-rhel-7-BZ123456', 'rhel-7-staging-candidate'),
-            ('private-staging-rhel-6-BZ654321', 'rhel-6-staging-candidate'),
-            ('private-jo-fo-staging-rhel-6-bar-baz', 'rhel-6-staging-candidate'),
-            ('private-johnfoo-staging-extras-rhel-7', 'extras-rhel-7-staging-candidate'),
-            ('private-johnfoo-staging-extras-rhel-7-BZ123456', 'extras-rhel-7-staging-candidate'),
-            ('private-staging-extras-rhel-6-BZ654321', 'extras-rhel-6-staging-candidate'),
-            ('private-jo-fo-staging-extras-rhel-6-bar-baz', 'extras-rhel-6-staging-candidate'),
+            ('private-johnfoo-staging-rhel-7', 'staging-rhel-7-candidate'),
+            ('private-johnfoo-staging-rhel-7-BZ123456', 'staging-rhel-7-candidate'),
+            ('private-staging-rhel-6-BZ654321', 'staging-rhel-6-candidate'),
+            ('private-jo-fo-staging-rhel-6-bar-baz', 'staging-rhel-6-candidate'),
+            ('private-johnfoo-staging-extras-rhel-7', 'staging-extras-rhel-7-candidate'),
+            ('private-johnfoo-staging-extras-rhel-7-BZ123456', 'staging-extras-rhel-7-candidate'),
+            ('private-staging-extras-rhel-6-BZ654321', 'staging-extras-rhel-6-candidate'),
+            ('private-jo-fo-staging-extras-rhel-6-bar-baz', 'staging-extras-rhel-6-candidate'),
         ]
 
         for branch, target in testing_data:

--- a/build-on-push/platform_ci/platform_ci/distgit_test.py
+++ b/build-on-push/platform_ci/platform_ci/distgit_test.py
@@ -17,20 +17,22 @@ import unittest
 # pylint: disable=no-name-in-module
 from nose.tools import assert_raises
 
-from .distgit import DistGitBranch, DistGitBranchException
+from platform_ci.distgit import DistGitBranch, DistGitBranchException
 
 
 class DistGitBranchTest(unittest.TestCase):
-    STAGING = {"branch": "rhel-7.1-staging", "target": "rhel-7.1-candidate"}
+    STAGING = {"branch": "staging-rhel-7", "target": "rhel-7-staging-candidate"}
     PRIVATE = {"branch": "private-pmuller-branch", "target": None}
-    STANDARD = {"branch": "extras-rhel-7.2", "target": "extras-rhel-7.2-candidate"}
-    EXTRAS_STAGING = {"branch": "extras-rhel-7.2-staging", "target": "extras-rhel-7.2-candidate"}
+    STANDARD = {"branch": "rhel-7.2", "target": "rhel-7.2-candidate"}
+    EXTRAS_STANDARD = {"branch": "extras-rhel-7.2", "target": "extras-rhel-7.2-candidate"}
+    EXTRAS_STAGING = {"branch": "staging-extras-rhel-7", "target": "extras-rhel-7-staging-candidate"}
 
     def setUp(self):
         self.staging_branch = DistGitBranch(DistGitBranchTest.STAGING["branch"])
         self.private_branch = DistGitBranch(DistGitBranchTest.PRIVATE["branch"])
         self.extras_staging_branch = DistGitBranch(DistGitBranchTest.EXTRAS_STAGING["branch"])
         self.standard_branch = DistGitBranch(DistGitBranchTest.STANDARD["branch"])
+        self.extras_standard_branch = DistGitBranch(DistGitBranchTest.EXTRAS_STANDARD["branch"])
 
     def extras_staging_branch_test(self):
         assert self.extras_staging_branch.name == DistGitBranchTest.EXTRAS_STAGING["branch"]
@@ -53,23 +55,29 @@ class DistGitBranchTest(unittest.TestCase):
     def standard_branch_test(self):
         assert self.standard_branch.name == DistGitBranchTest.STANDARD["branch"]
         assert not self.standard_branch.is_staging()
-        print self.standard_branch.staging_target
         assert self.standard_branch.staging_target == DistGitBranchTest.STANDARD["target"]
         assert self.standard_branch.type == "standard"
+
+    def extras_standard_branch_test(self):
+        assert self.extras_standard_branch.name == DistGitBranchTest.EXTRAS_STANDARD["branch"]
+        assert not self.extras_standard_branch.is_staging()
+        assert self.extras_standard_branch.staging_target == DistGitBranchTest.EXTRAS_STANDARD["target"]
+        assert self.extras_standard_branch.type == "standard"
 
     # pylint: disable=no-self-use
     def rhscl_staging_branch_test(self):
         """
         Tests for parsing staging branches for RHSCL and determining the correct build target
         """
-        testing_branches = [
-            'rhscl-2.1-rh-ruby22-rhel-6-staging',
-            'rhscl-2.1-rh-ruby22-rhel-7-staging',
-            'rhscl-2.1-rh-mariadb100-rhel-6-staging',
-            'rhscl-2.1-rh-mariadb100-rhel-7-staging'
+        testing_bases = [
+            'rhscl-2.1-rh-ruby22-rhel-6',
+            'rhscl-2.1-rh-ruby22-rhel-7',
+            'rhscl-2.1-rh-mariadb100-rhel-6',
+            'rhscl-2.1-rh-mariadb100-rhel-7'
         ]
 
-        testing_targets = [branch.replace('staging', 'candidate') for branch in testing_branches]
+        testing_branches = ["staging-{0}".format(base) for base in testing_bases]
+        testing_targets = ["{0}-staging-candidate".format(base) for base in testing_bases]
 
         for branch, target in zip(testing_branches, testing_targets):
             obj = DistGitBranch(branch)
@@ -83,10 +91,13 @@ class DistGitBranchTest(unittest.TestCase):
         Tests for parsing private staging branches for RHSCL and determining the correct build target
         """
         testing_data = [
-            ('private-johnfoo-rhscl-2.1-rh-ruby22-rhel-6-staging', 'rhscl-2.1-rh-ruby22-rhel-6-candidate'),
-            ('private-johnfoo-rhscl-2.1-rh-ruby22-rhel-7-staging-BZ123456', 'rhscl-2.1-rh-ruby22-rhel-7-candidate'),
-            ('private-rhscl-2.1-rh-mariadb100-rhel-6-staging-BZ654321', 'rhscl-2.1-rh-mariadb100-rhel-6-candidate'),
-            ('private-jo-fo-rhscl-2.1-rh-mariadb100-rhel-7-staging-bar-baz', 'rhscl-2.1-rh-mariadb100-rhel-7-candidate')
+            ('private-johnfoo-staging-rhscl-2.1-rh-ruby22-rhel-6', 'rhscl-2.1-rh-ruby22-rhel-6-staging-candidate'),
+            ('private-johnfoo-staging-rhscl-2.1-rh-ruby22-rhel-7-BZ123456',
+             'rhscl-2.1-rh-ruby22-rhel-7-staging-candidate'),
+            ('private-staging-rhscl-2.1-rh-mariadb100-rhel-6-BZ654321',
+             'rhscl-2.1-rh-mariadb100-rhel-6-staging-candidate'),
+            ('private-jo-fo-staging-rhscl-2.1-rh-mariadb100-rhel-7-bar-baz',
+             'rhscl-2.1-rh-mariadb100-rhel-7-staging-candidate')
         ]
 
         for branch, target in testing_data:
@@ -101,14 +112,14 @@ class DistGitBranchTest(unittest.TestCase):
         Tests for parsing private staging branches for RHEL components and determining the correct build target
         """
         testing_data = [
-            ('private-johnfoo-rhel-7.3-staging', 'rhel-7.3-candidate'),
-            ('private-johnfoo-rhel-7.3-staging-BZ123456', 'rhel-7.3-candidate'),
-            ('private-rhel-6.8-staging-BZ654321', 'rhel-6.8-candidate'),
-            ('private-jo-fo-rhel-6.8-staging-bar-baz', 'rhel-6.8-candidate'),
-            ('private-johnfoo-extras-rhel-7.3-staging', 'extras-rhel-7.3-candidate'),
-            ('private-johnfoo-extras-rhel-7.3-staging-BZ123456', 'extras-rhel-7.3-candidate'),
-            ('private-extras-rhel-6.8-staging-BZ654321', 'extras-rhel-6.8-candidate'),
-            ('private-jo-fo-extras-rhel-6.8-staging-bar-baz', 'extras-rhel-6.8-candidate'),
+            ('private-johnfoo-staging-rhel-7', 'rhel-7-staging-candidate'),
+            ('private-johnfoo-staging-rhel-7-BZ123456', 'rhel-7-staging-candidate'),
+            ('private-staging-rhel-6-BZ654321', 'rhel-6-staging-candidate'),
+            ('private-jo-fo-staging-rhel-6-bar-baz', 'rhel-6-staging-candidate'),
+            ('private-johnfoo-staging-extras-rhel-7', 'extras-rhel-7-staging-candidate'),
+            ('private-johnfoo-staging-extras-rhel-7-BZ123456', 'extras-rhel-7-staging-candidate'),
+            ('private-staging-extras-rhel-6-BZ654321', 'extras-rhel-6-staging-candidate'),
+            ('private-jo-fo-staging-extras-rhel-6-bar-baz', 'extras-rhel-6-staging-candidate'),
         ]
 
         for branch, target in testing_data:


### PR DESCRIPTION
This commit follows the newly agreed (and probably) final decisions on staging branch structure, names and build target mappings.

The changes are summarized as follows:
1.  There will be just one staging branch per major product release, and it will be _prefixed_ with staging- rather than suffixed. Example: new staging branches are called _staging-rhel-7_ instead of earlier _rhel-7.2-staging_.
2. CI does not attempt to map a branch to an appropriate target anymore, instead a wildcard target _staging-rhel-7-candidate_ will be used, and RCM will take the responsibility for making sure this target always uses latest build tag available.

The jobs using this candidate code were deployed to stage:
1. _Component setup:_ 'platform-component-setup-testing'
2. _Commit dispatcher:_ 'ci-setup-dispatcher-commit', build 43 was performed using the candidate code and PASSed.
3. _BoP worker:_ 'ci-setup-commit-staging-rhel-7', build 1 was triggered by the dispatcher run above and correctly scheduled a build against staging-rhel-7-candidate target.

In short: everything seems to work as expected :)
