### PR TITLE
BoP: Notification fixes

### DIFF
--- a/build-on-push/jjb/platform-commit.yaml
+++ b/build-on-push/jjb/platform-commit.yaml
@@ -131,6 +131,8 @@
             export PYTHONPATH="$PYTHONPATH:platform-ci/build-on-push/platform_ci"
 
             job-commit-worker.sh "{component}" "{git-branch}"
+        - inject:
+            properties-file: $WORKSPACE/VALUES.txt
     wrappers:
         - default-ci-workflow-wrappers
     publishers:
@@ -138,7 +140,7 @@
             artifacts: '*.log, *.txt'
             allow-empty: 'true'
         - email-ext:
-            recipients: '${{FILE,path="addresses.txt"}}'
+            recipients: $NOTIFICATION_RECIPENTS
             reply-to: $DEFAULT_REPLYTO
             content-type: default
             subject: 'CI: $PROJECT_NAME #$BUILD_NUMBER ($BUILD_STATUS)'

--- a/build-on-push/jjb/platform-commit.yaml
+++ b/build-on-push/jjb/platform-commit.yaml
@@ -146,7 +146,7 @@
             subject: 'CI: $PROJECT_NAME #$BUILD_NUMBER ($BUILD_STATUS)'
             body: ${{FILE,path="notification-email.txt"}}
             attach-build-log: false
-            always: false
+            always: true
             unstable: true
             first-failure: true
             not-built: true

--- a/build-on-push/jjb/platform-commit.yaml
+++ b/build-on-push/jjb/platform-commit.yaml
@@ -140,7 +140,7 @@
             artifacts: '*.log, *.txt'
             allow-empty: 'true'
         - email-ext:
-            recipients: $NOTIFICATION_RECIPENTS
+            recipients: $NOTIFICATION_RECIPIENTS
             reply-to: $DEFAULT_REPLYTO
             content-type: default
             subject: 'CI: $PROJECT_NAME #$BUILD_NUMBER ($BUILD_STATUS)'

--- a/build-on-push/scripts/ci_commit
+++ b/build-on-push/scripts/ci_commit
@@ -112,6 +112,18 @@ def run(args):
     commit_ci.consider_build(commit, args.slave, platform_ci_source, config_file)
 
 
+def get_author():
+    command = ["git", "--no-pager", "show", "-s", "--format=%ce", "HEAD"]
+
+    git_commiter_query = subprocess.Popen(command, stdout=subprocess.PIPE)
+    git_commiter_query.wait()
+    if git_commiter_query.returncode != 0:
+        raise subprocess.CalledProcessError(git_commiter_query.returncode, command)
+
+    author = git_commiter_query.communicate()[0].strip()
+    return author
+
+
 def build(args):
     """Issue a scratch build request on a given branch.
 
@@ -130,26 +142,18 @@ def build(args):
         args.targets: A list of Brew targets for which builds will be attempted.
         args.report: A path to a file where the notification message body will
             be written.
+        args.values: An file-like object opened for writing, where KEY=VALUE
+            records will be written.
     """
     logging.info("Checking out branch %s of git repository %s", args.branch, args.component)
-
-    if args.addresses:
-        addresses_file = open(args.addresses, "w")
 
     cwd = os.getcwd()
     os.chdir(args.component)
 
     subprocess.check_call(["git", "branch", "--set-upstream", args.branch, "origin/{0}".format(args.branch)])
 
-    if args.addresses:
-        command = ["git", "--no-pager", "show", "-s", "--format=%ce", "HEAD"]
-        git_commiter_query = subprocess.Popen(command, stdout=subprocess.PIPE)
-        author = git_commiter_query.communicate()[0].strip()
-        git_commiter_query.wait()
-        if git_commiter_query.returncode != 0:
-            raise subprocess.CalledProcessError(git_commiter_query.returncode, command)
-        addresses_file.write(author)
-        addresses_file.close()
+    author = get_author()
+    args.values.write("NOTIFICATION_RECIPIENTS={0}".format(author))
 
     builds = BrewBuildAttempts(args.targets, cwd)
     builds.execute()
@@ -230,7 +234,8 @@ def main():
     parser_build.add_argument("component")
     parser_build.add_argument("branch")
     parser_build.add_argument("targets", nargs="+")
-    parser_build.add_argument("--committer-emails", dest="addresses", metavar="FILE", default=None)
+    parser_build.add_argument("--values-file", dest="values", metavar="FILE", type=argparse.FileType('w'),
+                              default="/dev/null")
     parser_build.set_defaults(func=build)
 
     logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)

--- a/build-on-push/scripts/job-commit-worker.sh
+++ b/build-on-push/scripts/job-commit-worker.sh
@@ -23,9 +23,9 @@ BRANCH="$2"
 
 . "$BOP_HOME/scripts/functions"
 
-rm -f "$WORKSPACE/notification-email.txt" "$WORKSPACE/addresses.txt"
+rm -f "$WORKSPACE/notification-email.txt"
 
-if ! ci_commit --report notification-email.txt build "$PROJECT" "$BRANCH" $BREW_TARGETS --committer-emails=addresses.txt
+if ! ci_commit --report notification-email.txt build "$PROJECT" "$BRANCH" $BREW_TARGETS --values-file="$WORKSPACE/VALUES.txt"
 then
 	exit 1
 fi


### PR DESCRIPTION
Previously the notifications did not work because of bad recipient setup (issue #30). This PR fixes it. Additionally, it sets notifications to be sent always instead of only after a failure/result change. Developers were confused when they received no notification.
