### PR TITLE
Add ci metrics listener and jjb snippets example

### DIFF
--- a/ELK_Listener/ci_listener.yaml
+++ b/ELK_Listener/ci_listener.yaml
@@ -1,3 +1,4 @@
+# test test
 - job-template:
     name: 'CI-Metrics-Data-Listener'
     description: |

--- a/ELK_Listener/ci_listener.yaml
+++ b/ELK_Listener/ci_listener.yaml
@@ -217,15 +217,20 @@
 
             # Case 2 (job metrics)
             elif os.environ["CI_TYPE"] == 'ci-metricsdata':
-                 if 'build_type' in parsed_json.keys():
-                    # Dont store logs for scratch builds
-                    if parsed_json['build_type'] == 'scratch':
-                         print("scratch is true. Exiting..")
-                         sys.exit()
 
                  # ISO8601 regex.  We use this for metrics timestamps
                  iso8601 = re.compile(r'(\d{{4}})-(0[1-9]|1[0-2])-(0[1-9]|1[0-9]|2[0-9]|3[01])(|[tT\s])(0[0-9]|1[0-9]|2[0-3]):(0[0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9]):(0[0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9])Z')
                  expected_Keys=['component', 'trigger', 'tests', 'job_link_back', 'base_distro', 'compose_id', 'brew_task_id', 'create_time', 'completion_time', 'CI_infra_failure', 'CI_infra_failure_desc', 'job_names', 'CI_tier', 'build_type', 'owner', 'content-length', 'destination', 'expires', 'xunit_links']
+
+                 # Get the docid now so we can look up old logs
+                 if ('component' in parsed_json.keys()) and ('brew_task_id' in parsed_json.keys()):
+                      docid = parsed_json['component']+'-'+parsed_json['brew_task_id']
+                 else:
+                      print("Could not find component/task_id in metrics data.  Exiting...")
+                      sys.exit()
+
+                 old_log_json = subprocess.Popen(['curl', '--ipv4', '-XGET', '{server}:9200/{index}/log/'+docid+'?pretty'], stdout=subprocess.PIPE).communicate()[0]
+                 old_log = json.loads(old_log_json)
 
                  # Check to see if we're getting the keys we expect
                  # If we have unexpected keys, we know to add it and
@@ -247,24 +252,133 @@
                            if (value != 'manual') and (value != 'git') and (value != 'commit') and (value != 'git push') and (value != 'rhpkg build') and (value != 'brew build'):
                                 value = 'null'
                            parsed_json[key] = value
+                      elif key == 'tests' and '_source' in old_log.keys():
+                           for i, tester in enumerate(parsed_json['tests']):
+                                if tester['executor'] == 'beaker':
+                                     # Find out how many jobs have
+                                     # already been reported by old_log
+                                     JOBS_REPORTED = 1
+                                     JOBS_LIST = []
+                                     if 'job_names' in parsed_json.keys():
+                                          JOBS_LIST.append(parsed_json['job_names'])
+                                     else:
+                                          # Dummy name to be replaced later
+                                          JOBS_LIST.append("00000")
+                                     for key in old_log['_source'].keys():
+                                          if key.startswith( 'job_names' ):
+                                               JOBS_REPORTED = JOBS_REPORTED + 1
+                                               JOBS_LIST.append(old_log['_source'][key])
+                                               JOBS_LIST.sort()
+                                     # Have to be careful about not reusing values here, so 
+                                     # rewrite dummy job with appropriate number of preexisting jobs
+                                     if 'job_names' not in parsed_json.keys():
+                                          JOBS_LIST[0] = "DUMMY_" + str(JOBS_REPORTED)
+                                     for index in range (0,JOBS_REPORTED):
+                                          JOB_TO_ADD=JOBS_LIST[index]
+                                          if index == 0:
+                                               # This job is the new one, tester is incoming metrics data
+                                               parsed_json['beaker_job_1'] = JOB_TO_ADD
+                                               if not tester['executed'].isdigit():
+                                                    tester['executed'] = '-1'
+                                               parsed_json['beaker_tests_exec_1'] = tester['executed']
+                                               parsed_json['beaker_arch_1'] = tester['arch']
+                                               if not tester['failed'].isdigit():
+                                                    tester['failed'] = '-1'
+                                               parsed_json['beaker_tests_failed_1'] = tester['failed']
+                                          else:
+                                               # This job is from old log, so was already stored
+                                               myval = 0
+                                               # Get index of job from old log
+                                               # This only supports up to 9 preexisting jobs
+                                               # as key[-1:] only gets the last integer
+                                               for key in old_log['_source'].keys():
+                                                    if key.startswith( 'beaker_job' ):
+                                                         if old_log['_source'][key] == JOB_TO_ADD:
+                                                              myval = key[-1:]
+                                               if myval == 0:
+                                                    print("How did we not find the number associated with this key? %s" % key)
+                                               else:
+                                                    parsed_json['beaker_job_'+str(index+1)] = old_log['_source']['beaker_job_'+str(myval)]
+                                                    parsed_json['beaker_arch_'+str(index+1)] = old_log['_source']['beaker_arch_'+str(myval)]
+                                                    parsed_json['beaker_tests_exec_'+str(index+1)] = old_log['_source']['beaker_tests_exec_'+str(myval)]
+                                                    parsed_json['beaker_tests_failed_'+str(index+1)] = old_log['_source']['beaker_tests_failed_'+str(myval)]
+                                elif tester['executor'] == 'CI-OSP':
+                                     # Find out how many jobs have
+                                     # already been reported by old_log
+                                     JOBS_REPORTED = 1
+                                     JOBS_LIST = []
+                                     if 'job_names' in parsed_json.keys():
+                                          JOBS_LIST.append(parsed_json['job_names'])
+                                     else:
+                                          # Dummy name to be replaced later
+                                          JOBS_LIST.append("00000")
+                                     for key in old_log['_source'].keys():
+                                          if key.startswith( 'job_names' ):
+                                               JOBS_REPORTED = JOBS_REPORTED + 1
+                                               JOBS_LIST.append(old_log['_source'][key])
+                                               JOBS_LIST.sort()
+                                     # Have to be careful about not reusing values here, so 
+                                     # rewrite dummy job with appropriate number of preexisting jobs
+                                     if 'job_names' not in parsed_json.keys():
+                                          JOBS_LIST[0] = "DUMMY_" + str(JOBS_REPORTED)
+                                     for index in range (0,JOBS_REPORTED):
+                                          JOB_TO_ADD=JOB_LIST[index]
+                                          if index == 0:
+                                               # This job is the new one, tester is incoming metrics data
+                                               parsed_json['ciosp_job_1'] = JOB_TO_ADD
+                                               if not tester['executed'].isdigit():
+                                                    tester['executed'] = '-1'
+                                               parsed_json['ciosp_tests_exec_1'] = tester['executed']
+                                               if not tester['failed'].isdigit():
+                                                    tester['failed'] = '-1'
+                                               parsed_json['ciosp_tests_failed_1'] = tester['failed']
+                                               parsed_json['ciosp_arch_1'] = tester['arch']
+                                          else:
+                                               # This job is from old log, so was already stored
+                                               myval = 0
+                                               # Get index of job from old log
+                                               # This only supports up to 9 preexisting jobs
+                                               # as key[-1:] only gets the last integer
+                                               for key in old_log['_source'].keys():
+                                                    if key.startswith( 'ciosp_job' ):
+                                                         if old_log['_source'][key] == JOB_TO_ADD:
+                                                              myval = key[-1:]
+                                               if myval == 0:
+                                                    print("How did we not find the number associated with this key? %s" % key)
+                                               else:
+                                                    parsed_json['ciosp_job_'+str(index+1)] = old_log['_source']['ciosp_job_'+str(myval)]
+                                                    parsed_json['ciosp_arch_'+str(index+1)] = old_log['_source']['ciosp_arch_'+str(myval)]
+                                                    parsed_json['ciosp_tests_exec_'+str(index+1)] = old_log['_source']['ciosp_tests_exec_'+str(myval)]
+                                                    parsed_json['ciosp_tests_failed_'+str(index+1)] = old_log['_source']['ciosp_tests_failed_'+str(myval)]
+                                else:
+                                     print('Unsupported test executor!')
+                           del parsed_json['tests'] 
                       elif key == 'tests':
                            for i, tester in enumerate(value):
                                 if tester['executor'] == 'beaker':
-                                     parsed_json['beaker_arch'] = tester['arch']
+                                     if 'job_names' in parsed_json.keys():
+                                          parsed_json['beaker_job_1'] = parsed_json['job_names']
+                                     else:
+                                          parsed_json['beaker_job_1'] = 'DUMMY_1'
+                                     parsed_json['beaker_arch_1'] = tester['arch']
                                      if not tester['executed'].isdigit():
                                           tester['executed'] = '-1'
-                                     parsed_json['beaker_tests_exec'] = tester['executed']
+                                     parsed_json['beaker_tests_exec_1'] = tester['executed']
                                      if not tester['failed'].isdigit():
                                           tester['failed'] = '-1'
-                                     parsed_json['beaker_tests_fail'] = tester['failed']
+                                     parsed_json['beaker_tests_failed_1'] = tester['failed']
                                 elif tester['executor'] == 'CI-OSP':
-                                     parsed_json['ciosp_arch'] = tester['arch']
+                                     if 'job_names' in parsed_json.keys():
+                                          parsed_json['ciosp_job_1'] = parsed_json['job_names']
+                                     else:
+                                          parsed_json['beaker_job_1'] = 'DUMMY_1'
+                                     parsed_json['ciosp_arch_1'] = tester['arch']
                                      if not tester['executed'].isdigit():
                                           tester['executed'] = '-1'
-                                     parsed_json['ciosp_tests_exec'] = tester['executed']
+                                     parsed_json['ciosp_tests_exec_1'] = tester['executed']
                                      if not tester['failed'].isdigit():
                                           tester['failed'] = '-1'
-                                     parsed_json['ciosp_tests_fail'] = tester['failed']
+                                     parsed_json['ciosp_tests_failed_1'] = tester['failed']
                                 else:
                                      print('Unsupported test executor!')
                            del parsed_json[key]
@@ -345,8 +459,8 @@
 ## Describes the project
 - project:
     name: ci-metrics-listener
-    server: ELKSERVER
-    pdc_rpm_link: LINKTOPDC/RPMS
+    server: SERVER
+    pdc_rpm_link: PDC_LINK/api/v1/rpms
     index: brew-taskstatechange
     jobs:
       - ci-metricsdata-listener

--- a/ELK_Listener/ci_listener.yaml
+++ b/ELK_Listener/ci_listener.yaml
@@ -1,0 +1,352 @@
+- job-template:
+    name: 'CI-Metrics-Data-Listener'
+    description: |
+        Managed by Jenkins Job Builder. Do not edit via web
+    concurrent: false
+    node: master
+    triggers:
+        - ci-trigger:
+            jms-selector: "(CI_TYPE = '{index}' AND method = 'build' AND scratch = FALSE) OR (CI_TYPE = 'ci-metricsdata')"
+    builders:
+        - shell: |
+            #!/bin/bash
+            kinit -k -t $KEYTAB $PRINCIPAL
+            # We use both bash and python so cat the python to its own file
+            cat << "EOF" > $WORKSPACE/metricsdatalistener.py
+            #!/usr/bin/env python
+            import sys
+            import os
+            import json
+            import subprocess
+            import re
+            import time
+            import pdc_client
+            import numbers
+            import dateutil.parser as dp
+
+            # Extract CI_MESSAGE from message
+            if "CI_MESSAGE" in os.environ:
+                message = os.environ["CI_MESSAGE"]
+                parsed_json = json.loads(message)
+            else:
+                parsed_json = json.loads(sys.stdin)
+
+            # Print the environment to console log for debugging purposes
+            for key in os.environ.keys():
+                 print "%s=%s" % (key, os.environ[key])
+
+            # If the index does not yet exist, put it there
+            hostindex = '{server}:9200/{index}'
+            # This template is for elasticsearch and allows timestamp to be your time field
+            # It also adds the .raw fields so you can use the fields to create visualizations in kibana
+            indextemplate = '{{"mappings":{{"log":{{"properties":{{"timestamp":{{"type":"date"}}}},"dynamic_templates":[{{"message_field":{{"match":"message","match_mapping_type":"string","mapping":{{"type":"string","index":"analyzed","omit_norms":true}}}}}},{{"string_fields":{{"match":"*","match_mapping_type":"string","mapping":{{"type":"string","index":"analyzed","omit_norms":true,"fielddata":{{"format":"disabled"}},"fields":{{"raw":{{"type":"string","index":"not_analyzed","doc_values":true}}}}}}}}}}]}}}}}}'
+            indexes = subprocess.Popen(['curl', '-s', '--ipv4', '{server}:9200/_cat/indices?v'], stdout=subprocess.PIPE).communicate()[0]
+            # We use {index} as the index in kibana, which is also what
+            # CI Type we are listening for.  If the index is not on the host yet
+            # put it there
+            if '{index}' not in indexes:
+                 subprocess.call(['curl', '--ipv4', '-XPUT', "%s?pretty" % hostindex, '-d', indextemplate])
+
+            # Case 1
+            if os.environ["CI_TYPE"] == '{index}':
+                 if "scratch" in os.environ:
+                    if os.environ["scratch"] == 'true':
+                         # This should never happen due to the jms selector
+                         print("scratch is true. Exiting..")
+                         sys.exit()
+                 # We want nvr so we can use it as our elasticsearch ID
+                 if "name" in os.environ:
+                    n = os.environ["name"]
+                 else:
+                    n = ''
+                 if "version" in os.environ:
+                    v = os.environ["version"]
+                 else:
+                    v = ''
+                 if "release" in os.environ:
+                    r = os.environ["release"]
+                 else:
+                    r = ''
+      
+                 # Create regex so we can check if our logs from brew use the expected time format
+                 brew_time_format = re.compile(r'(\d{{4}})-(0[1-9]|1[0-2])-(0[1-9]|1[0-9]|2[0-9]|3[01]) (0[0-9]|1[0-9]|2[0-3]):(0[0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9]):(0[0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9]).[0-9][0-9][0-9][0-9][0-9][0-9]')
+                 # We want to discard packages built against the docs target
+                 ignore_docs_target = re.compile(r'(docs)')
+
+                 # Add field that shows package was built in brew for visualizations in kibana
+                 parsed_json['Brew Built'] = 'true'
+      
+                 # Extract fields from message header
+                 if "target" in os.environ:
+                      parsed_json['target'] = os.environ["target"]
+                      if ignore_docs_target.match(parsed_json['target']):
+                           print('We dont want doc nvrs. Exiting..')
+                           sys.exit()
+                 if "scratch" in os.environ:
+                      parsed_json['scratch'] = os.environ["scratch"]
+
+                 # Extract fields from message body
+                 # For fields I am not yet sure of any restrictions on, 
+                 # I just pass the key value pair along to parsed_json
+                 # For fields I dont think we need, I just do a pass
+                 for key, value in parsed_json['info'].items():
+                      if key == 'weight':
+                           parsed_json[key] = value
+                      elif key == 'parent':
+                           parsed_json[key] = value
+                      elif key == 'channel_id':
+                           if not str(value).isdigit():
+                                parsed_json[key] = '-1'
+                      elif key == 'request':
+                           pass
+                      elif key == 'start_time':
+                           if not brew_time_format.match(value):
+                                parsed_json[key] = 'START_TIME_NOT_VALID'
+                      elif key == 'start_ts':
+                           if isinstance(value, numbers.Real):
+                                parsed_json[key] = value
+                           else:
+                                parsed_json[key] = 'Invalid Timestamp!'
+                      elif key == 'waiting':
+                           parsed_json[key] = value
+                      elif key == 'awaited':
+                           parsed_json[key] = value
+                      elif key == 'label':
+                           parsed_json[key] = value
+                      elif key == 'priority':
+                           if not str(value).isdigit():
+                                parsed_json[key] = '-1'
+                      elif key == 'completion_time':
+                           if not brew_time_format.match(value):
+                                parsed_json[key] = 'COM_TIME_NOT_VALID'
+                                parsed_json['timestamp'] = (int(time.time())*1000)
+                           else:
+                                parsed_json[key] = value
+                      elif key == 'state':
+                           if not str(value).isdigit():
+                                parsed_json[key] = '-1'
+                      elif key == 'create_time':
+                           if not brew_time_format.match(value):
+                                parsed_json[key] = 'CREATE_TIME_NOT_VALID'
+                           else:
+                                parsed_json[key] = value
+                      elif key == 'create_ts':
+                           if isinstance(value, numbers.Real):
+                                parsed_json[key] = value
+                           else:
+                                parsed_json[key] = 'Invalid Timestamp!'
+                      elif key == 'owner':
+                           parsed_json[key] = value
+                      elif key == 'host_id':
+                           if not str(value).isdigit():
+                                parsed_json[key] = '-1'
+                      elif key == 'method':
+                           parsed_json[key] = value
+                      elif key == 'completion_ts':
+                           if isinstance(value, numbers.Real):
+                                # We need to create the timestamp field for elasticsearch
+                                parsed_json['timestamp'] = ("%.0f" % float(str(value*1000).split("\.")[0]))
+                           else:
+                                parsed_json['timestamp'] = (int(time.time())*1000)
+                                parsed_json[key] = 'Invalid Timestamp!'
+                      elif key == 'arch':
+                           parsed_json[key] = value
+                      elif key == 'id':
+                           if not str(value).isdigit():
+                                parsed_json[key] = '-1'
+                           parsed_json['brew_task_id'] = value
+                      elif key == 'result':
+                           parsed_json[key] = value
+                      else: # Did not expect this key!
+                           parsed_json[key] = value
+      
+      
+                 # These fields aren't formatted properly for our output
+                 # so we previously added their items individually, now 
+                 # we delete them
+                 keys_to_remove = ['info', 'rpms']
+                 for key in keys_to_remove:
+                      del parsed_json[key]
+      
+                 # We use nvr+brew_task_id as our elasticsearch docid
+                 parsed_json['nvr'] = n+'-'+v+'-'+r
+                 docid = "%s-%s" % (parsed_json['nvr'], str(parsed_json['brew_task_id']))
+                 # It is pivotal the doc has a timestamp for storing it
+                 if 'timestamp' not in parsed_json.keys():
+                      parsed_json['timestamp'] = (int(time.time())*1000)
+
+                 # rhel-6.9 is not in the PDC yet so we need to use 
+                 # rhel-6.8 as a fallback for these packages
+                 if 'target' in parsed_json.keys() and parsed_json['target'][:8] == 'rhel-6.9':
+                      # Get archs we expect to be tested via these
+                      # commands from the PDC
+                      pdc = pdc_client.PDCClient("prod")
+                      try:
+                           ret = pdc['releases']['rhel-6.8']["rpm-mapping"][n]._()
+                           expected_archs = ''
+                           mymap = 'changeme'
+                           for candidate in ret['mapping'].keys():
+                                if candidate[:6] == 'Server':
+                                     mymap = candidate
+                                     break
+                           if mymap in ret['mapping']:
+                                for key in ret['mapping'][mymap].keys():
+                                     if key != 'src':
+                                          expected_archs = expected_archs + key + ' '
+                                expected_archs = expected_archs[:-1]
+                           parsed_json['expected_archs'] = expected_archs
+                      except:
+                           print('WARNING! PDC Call Failed! Got a rhel-6.9 package so looked it up with rhel-6.8, but didnt find it')
+                 else:
+                      # Look up package by NVR in the PDC
+                      try:
+                           PDC_message = subprocess.Popen(['curl', '--insecure', '-XGET', '{pdc_rpm_link}/?name=^%s$&version=%s&release=%s' % (n, v, r)], stdout=subprocess.PIPE).communicate()[0]
+                           PDC_parsed = json.loads(PDC_message)
+                           expected_archs = ''
+                           # If results isnt there, NVR was not in PDC
+                           # Can add else and sys.exit later
+                           # This adds the archs we expect to test for this nvr
+                           if 'results' in PDC_parsed:
+                                for id in PDC_parsed['results']:
+                                     if id['arch'] != 'src':
+                                          expected_archs = expected_archs + id['arch'] + ' '
+                                expected_archs = expected_archs[:-1]
+                                parsed_json['expected_archs'] = expected_archs
+                      except:
+                           print('Calling PDC by NVR failed with NVR = %s-%s-%s' % (n, v, r))
+
+            # Case 2 (job metrics)
+            elif os.environ["CI_TYPE"] == 'ci-metricsdata':
+                 if 'build_type' in parsed_json.keys():
+                    # Dont store logs for scratch builds
+                    if parsed_json['build_type'] == 'scratch':
+                         print("scratch is true. Exiting..")
+                         sys.exit()
+
+                 # ISO8601 regex.  We use this for metrics timestamps
+                 iso8601 = re.compile(r'(\d{{4}})-(0[1-9]|1[0-2])-(0[1-9]|1[0-9]|2[0-9]|3[01])(|[tT\s])(0[0-9]|1[0-9]|2[0-3]):(0[0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9]):(0[0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9])Z')
+                 expected_Keys=['component', 'trigger', 'tests', 'job_link_back', 'base_distro', 'compose_id', 'brew_task_id', 'create_time', 'completion_time', 'CI_infra_failure', 'CI_infra_failure_desc', 'job_names', 'CI_tier', 'build_type', 'owner', 'content-length', 'destination', 'expires', 'xunit_links']
+
+                 # Check to see if we're getting the keys we expect
+                 # If we have unexpected keys, we know to add it and
+                 # parse the value for correctness
+                 for key, value in parsed_json.items():
+                      if key not in expected_Keys:
+                           print('WARNING! Unexpected Key! ',key)
+                      if key in expected_Keys:
+                           expected_Keys.remove(key)
+
+                 for key, value in parsed_json.items():
+                      if key == 'component':
+                           if parsed_json[key].count('-') < 2:
+                                parsed_json['nvr'] = 'BAD NVR:'+value[:256]
+                           else:
+                                parsed_json['nvr'] = value[:256]
+                           del parsed_json[key]
+                      elif key == 'trigger':
+                           if (value != 'manual') and (value != 'git') and (value != 'commit') and (value != 'git push') and (value != 'rhpkg build') and (value != 'brew build'):
+                                value = 'null'
+                           parsed_json[key] = value
+                      elif key == 'tests':
+                           for i, tester in enumerate(value):
+                                if tester['executor'] == 'beaker':
+                                     parsed_json['beaker_arch'] = tester['arch']
+                                     if not tester['executed'].isdigit():
+                                          tester['executed'] = '-1'
+                                     parsed_json['beaker_tests_exec'] = tester['executed']
+                                     if not tester['failed'].isdigit():
+                                          tester['failed'] = '-1'
+                                     parsed_json['beaker_tests_fail'] = tester['failed']
+                                elif tester['executor'] == 'CI-OSP':
+                                     parsed_json['ciosp_arch'] = tester['arch']
+                                     if not tester['executed'].isdigit():
+                                          tester['executed'] = '-1'
+                                     parsed_json['ciosp_tests_exec'] = tester['executed']
+                                     if not tester['failed'].isdigit():
+                                          tester['failed'] = '-1'
+                                     parsed_json['ciosp_tests_fail'] = tester['failed']
+                                else:
+                                     print('Unsupported test executor!')
+                           del parsed_json[key]
+                      elif key == 'job_link_back':
+                           pass
+                      elif key == 'CI_tier':
+                           if not value.isdigit():
+                                parsed_json[key] = '-1'
+                      elif key == 'base_distro':
+                           parsed_json[key] = value[:256]
+                      elif key == 'compose_id':
+                           if not value.isdigit():
+                                parsed_json[key] = '000000'
+                      elif key == 'brew_task_id':
+                           if not value.isdigit():
+                                parsed_json[key] = '000000'
+                      elif key == 'create_time':
+                           if not iso8601.match(value):
+                                parsed_json[key] = 'CRE_TIME_NOT_ISO8601'
+                      elif key == 'completion_time':
+                           if not iso8601.match(value):
+                                parsed_json[key] = 'COM_TIME_NOT_ISO8601'
+                                parsed_json['timestamp'] = (int(time.time())*1000)
+                           else:
+                           # We end up 9 hours ahead somehow so correct back...
+                                parsed_json['timestamp'] = int(dp.parse(parsed_json[key]).strftime('%s'))*1000 - 32400000
+                      elif key == 'CI_infra_failure':
+                           pass
+                      elif key == 'CI_infra_failure_desc':
+                           parsed_json[key] = value[:1024]
+                      elif key == 'job_names':
+                           parsed_json[key] = value[:256]
+                      elif key == 'build_type':
+                           if (value != 'official') and (value != 'scratch'):
+                                value = 'null'
+                           parsed_json[key] = value[:64]
+                      elif key == 'owner':
+                           parsed_json[key] = value[:64]
+
+                 # Again we use nvr+brew_task_id as docid
+                 docid = parsed_json['nvr']+'-'+parsed_json['brew_task_id']
+                 # Add field that shows CI Testing was done for kibana visualizations
+                 parsed_json['CI Testing Done'] = 'true'
+                 if 'timestamp' not in parsed_json.keys():
+                      parsed_json['timestamp'] = (int(time.time())*1000)
+
+                 # Get the built in brew message for this NVR and append it with the CI metrics data
+                 old_log_json = subprocess.Popen(['curl', '--ipv4', '-XGET', '{server}:9200/{index}/log/'+docid+'?pretty'], stdout=subprocess.PIPE).communicate()[0]
+                 old_log = json.loads(old_log_json)
+                 # If _source not in old_log, there is no old log for this nvr
+                 if '_source' in old_log.keys():
+                      old_log['_source'].update(parsed_json)
+                      parsed_json = old_log['_source']
+
+                 # Find difference between actual and expected archs tested
+                 # This can be used to show testing process flaws at some point
+                 if 'beaker_arch' in parsed_json.keys() and 'expected_archs' in parsed_json.keys():
+                      arch_diff = cmp(sorted(parsed_json['beaker_arch'].split()), sorted(parsed_json['expected_archs'].split()))
+
+            # This should not happen
+            else:
+                 print('Unsupported CI_TYPE!')
+
+            output = json.dumps(parsed_json)
+
+            # Push the data to elasticsearch
+            subprocess.call(['curl', '--ipv4', '-XPUT', hostindex+'/log/'+docid, '-d', output])
+            EOF
+            chmod 755 $WORKSPACE/metricsdatalistener.py
+            python $WORKSPACE/metricsdatalistener.py
+
+## Grouping of jobs
+- job-group:
+    name: ci-metricsdata-listener
+    jobs:
+      - 'CI-Metrics-Data-Listener'
+
+## Describes the project
+- project:
+    name: ci-metrics-listener
+    server: ELKSERVER
+    pdc_rpm_link: LINKTOPDC/RPMS
+    index: brew-taskstatechange
+    jobs:
+      - ci-metricsdata-listener

--- a/ELK_Listener/ci_listener.yaml
+++ b/ELK_Listener/ci_listener.yaml
@@ -3,7 +3,7 @@
     description: |
         Managed by Jenkins Job Builder. Do not edit via web
     concurrent: false
-    node: master
+    node: 'jslave-platform'
     triggers:
         - ci-trigger:
             jms-selector: "(CI_TYPE = '{index}' AND method = 'build' AND scratch = FALSE) OR (CI_TYPE = 'ci-metricsdata')"

--- a/ELK_Listener/ci_listener.yaml
+++ b/ELK_Listener/ci_listener.yaml
@@ -1,4 +1,3 @@
-# test test
 - job-template:
     name: 'CI-Metrics-Data-Listener'
     description: |

--- a/ELK_Listener/install_elk.yaml
+++ b/ELK_Listener/install_elk.yaml
@@ -1,0 +1,94 @@
+## This playbook sets up a basic ELK instance.  After execution,
+## you will still need to create an index on the ELK instance
+## and send logs to the ELK instance
+
+- hosts: localhost
+  remote_user: root
+  tasks:
+  - name: Install wget
+    yum: name=wget state=latest
+  - name: wget the java jdk
+    command: 'wget --no-cookies --no-check-certificate --header "Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie" "http://download.oracle.com/otn-pub/java/jdk/8u73-b02/jdk-8u73-linux-x64.rpm"'
+    args:
+      chdir: /root
+  - name: yum localinstall the java jdk
+    yum: name=/root/jdk-8u73-linux-x64.rpm state=present
+  - name: Remove the java jdk
+    file: path=/root/jdk-8u73-linux-x64.rpm state=absent
+  - name: Insert elk repo
+    blockinfile:
+      dest: /etc/yum.repos.d/elk.repo
+      create: yes
+      block: |
+        [logstash-2.3]
+        name=Logstash repository for 2.3.x packages
+        baseurl=https://packages.elastic.co/logstash/2.3/centos
+        gpgcheck=1
+        gpgkey=https://packages.elastic.co/GPG-KEY-elasticsearch
+        enabled=1
+        [kibana-4.5]
+        name=Kibana repository for 4.5.x packages
+        baseurl=http://packages.elastic.co/kibana/4.5/centos
+        gpgcheck=1
+        gpgkey=http://packages.elastic.co/GPG-KEY-elasticsearch
+        enabled=1
+        [elasticsearch-2.x]
+        name=Elasticsearch repository for 2.x packages
+        baseurl=http://packages.elastic.co/elasticsearch/2.x/centos
+        gpgcheck=1
+        gpgkey=http://packages.elastic.co/GPG-KEY-elasticsearch
+        enabled=1
+        [Epel]
+        name=epel
+        baseurl=http://dl.fedoraproject.org/pub/epel/7/x86_64/
+        enabled=1
+        gpgcheck=0
+  - name: Do a yum clean all
+    command: yum clean all
+  - name: Install necessary packages
+    yum: pkg={{item}} state=installed
+    with_items:
+     - logstash
+     - kibana
+     - elasticsearch
+     - httpd
+     - epel-release
+     - nginx
+     - httpd-tools
+  - name: Change elasticsearch network host
+    replace: dest=/etc/elasticsearch/elasticsearch.yml regexp='# network.host{{ ":" }} 192.168.0.1' replace=' network.host{{ ":" }} 0.0.0.0'
+  - name: Need selinux to be permissive
+    command: setenforce 0
+  - name: Change kibana server host
+    replace: dest=/opt/kibana/config/kibana.yml regexp='# server.host{{ ":" }} "0.0.0.0"' replace=' server.host{{ ":" }} "localhost"'
+  - name: Remove server chunk from nginx conf
+    shell: 'head -n33 /etc/nginx/nginx.conf > /etc/nginx/nginx.conf.tmp'
+  - name: Add final closing brace to /etc/nginx/nginx.conf.tmp
+    shell: 'echo "}" >> /etc/nginx/nginx.conf.tmp'
+  - name: Replace nginx conf with new one
+    shell: 'mv -f /etc/nginx/nginx.conf.tmp /etc/nginx/nginx.conf'
+  - name: Create new nginx server definition
+    blockinfile:
+      dest: /etc/nginx/conf.d/kibana.conf
+      create: yes
+      block: |
+        server {
+          listen 80;
+
+          server_name localhost;
+
+          location / {
+             proxy_pass http://localhost:5601;
+             proxy_http_version 1.1;
+             proxy_set_header Upgrade $http_upgrade;
+             proxy_set_header Connection 'upgrade';
+             proxy_set_header Host $host;
+             proxy_cache_bypass $http_upgrade;
+          }
+        }
+  - name: Reload daemons with systemd
+    command: systemctl daemon-reload
+  - name: Enable all the services
+    command: systemctl enable nginx.service elasticsearch.service kibana.service logstash.service
+  - name: Start the services
+    command: systemctl start nginx.service elasticsearch.service kibana.service logstash.service

--- a/ELK_Listener/jjb_metrics_snippets.txt
+++ b/ELK_Listener/jjb_metrics_snippets.txt
@@ -1,0 +1,88 @@
+# This file shows what you can add to your jjb to
+# have it publish results out on the message bus.
+# This is not a complete JJB.  It shows what you
+# can add to be published in the build step. You
+# can decide to change publish whatever you would like.
+# This is currently set up to work with the ci listener
+# from this same directory.  Essentially, it shows how
+# to manually determine the variables of interest, then
+# publish them on the message bus using the Red Hat
+# CI jenkins plugin
+
+    builders:
+     - shell: |
+        #!/bin/bash
+
+        CREATE_TIME=$(date --utc +%FT%TZ)
+        .
+        .
+        <execution of job>
+        .
+        .
+        BKR_TESTS_EXEC=0
+        BKR_TESTS_FAILED=0
+        XUNIT_LINKS=''
+        # convert all recipeSets into Junit results (do not include failed installs)
+        for recipeSet in $(cat $WORKSPACE/recipeSets.txt); do
+            bkr job-results $recipeSet | xsltproc ./kernel/jenkins/helpers/recipeSet2junit.xml - > $WORKSPACE/${{recipeSet}}_xUnit.xml
+            BKR_TESTS_EXEC=$((BKR_TESTS_EXEC+$(cat $WORKSPACE/${{recipeSet}}_xUnit.xml | grep 'failures=' | cut -d "=" -f4 | cut -d '"' -f2)))
+            BKR_TESTS_FAILED=$((BKR_TESTS_FAILED+$(cat $WORKSPACE/${{recipeSet}}_xUnit.xml | grep 'failures=' | cut -d "=" -f5 | cut -d '"' -f2)))
+            XUNIT_LINKS="$XUNIT_LINKS $JOB_URL/$BUILD_NUMBER/artifact/${{recipeSet}}_xUnit.xml"
+        XUNIT_LINKS=$(echo "$XUNIT_LINKS" | tail -c +2)
+        done
+        ARCH=''
+        for myArch in $(bkr job-results $JOBID | xsltproc ./kernel/jenkins/helpers/job2metric.xsl - 2>&1 >/dev/null | cut -d ':' -f3 | sed -e 's/^[ \t]*//' | sort | uniq) ; do
+            ARCH="$ARCH $myArch"
+        done
+        ARCH=${{ARCH:1:256}}
+        TESTS=('[{{"executor": "beaker", "arch": "'"$ARCH"'", "executed": "'$BKR_TESTS_EXEC'", "failed": "'$BKR_TESTS_FAILED'"}}]')
+        CI_TIER=0
+        if [[ -z $job_group ]] ; then OWNER=$job_group ; else OWNER=$owner ; fi
+        if [[ "$scratch" = true ]] ; then BUILD=scratch ; else BUILD=official ; fi
+        BASE_DISTRO=''
+        DISTROS=$(bkr job-results $JOBID | xsltproc ./kernel/jenkins/helpers/job2metric.xsl - 2>&1 >/dev/null | cut -d ':' -f2 | sed -e 's/^[ \t]*//' | cut -d " " -f1 | sort | uniq)
+        if [[ $(echo $DISTROS | wc -l) -eq 1 ]]; then
+              BASE_DISTRO=$DISTROS
+        else
+              for myDistro in $(echo $DISTROS) ; do
+                   BASE_DISTRO="$BASE_DISTRO $myDistro"
+              done
+        fi
+        COMPLETION_TIME=$(date --utc +%FT%TZ)
+        echo "CREATE_TIME=$CREATE_TIME" >> $WORKSPACE/CI_NOTIFIER_VARS.txt
+        echo "TESTS=$TESTS" >> $WORKSPACE/CI_NOTIFIER_VARS.txt
+        echo "CI_TIER=$CI_TIER" >> $WORKSPACE/CI_NOTIFIER_VARS.txt
+        echo "OWNER=$OWNER" >> $WORKSPACE/CI_NOTIFIER_VARS.txt
+        echo "BUILD=$BUILD" >> $WORKSPACE/CI_NOTIFIER_VARS.txt
+        echo "BASE_DISTRO=$BASE_DISTRO" >> $WORKSPACE/CI_NOTIFIER_VARS.txt
+        echo "COMPLETION_TIME=$COMPLETION_TIME" >> $WORKSPACE/CI_NOTIFIER_VARS.txt
+        echo "XUNIT_LINKS=$XUNIT_LINKS" >> $WORKSPACE/CI_NOTIFIER_VARS.txt
+
+     - inject:
+         properties-file: $WORKSPACE/CI_NOTIFIER_VARS.txt
+
+     .
+     .
+     <whatever else your jjb needs>
+     .
+     .
+    publishers:
+      - ci-publisher:
+          message-type: 'Tier0TestingDone'
+          message-properties: |
+            CI_TYPE=ci-metricsdata
+          message-content: |
+            {{
+                "create_time": "$CREATE_TIME",
+                "tests": $TESTS,
+                "CI_tier": "$CI_TIER",
+                "owner": "$OWNER",
+                "build_type": "$BUILD",
+                "base_distro": "$BASE_DISTRO",
+                "completion_time": "$COMPLETION_TIME",
+                "component": "$name-$version-$release",
+                "job_link_back": "$JOB_URL",
+                "brew_task_id": "$id",
+                "job_names": "$JOB_NAME",
+                "xunit_links": "$XUNIT_LINKS"
+            }}

--- a/ELK_Listener/jjb_metrics_snippets.txt
+++ b/ELK_Listener/jjb_metrics_snippets.txt
@@ -68,7 +68,7 @@
      .
     publishers:
       - ci-publisher:
-          message-type: 'Tier0TestingDone'
+          message-type: 'Tier1TestingDone'
           message-properties: |
             CI_TYPE=ci-metricsdata
           message-content: |


### PR DESCRIPTION
Checking in a listener that will listen to the ci message bus and store
logs to a configured elasticsearch server.  All that is required is that elasticsearch
and kibana are configured properly on the server; it creates the index by itself 
in elasticsearch (will still need to create it in the kibana GUI).  The listener also
watches brew and stores a log whenever a new package is created.  Once testing
is done, the listener hears the message from the jenkins job if it is set up to publish
results to the message bus (included an example of this) and updates the elasticsearch
log to include this information as well.  You are left with elasticsearch logs that reflect
the number of tests run, the NVR, the number of tests passed, and information about the
archs.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>