### PR TITLE
Change in JJB to be able send messages to ci message bus

### DIFF
--- a/build-on-push/platform_ci/platform_ci/jenkins.py
+++ b/build-on-push/platform_ci/platform_ci/jenkins.py
@@ -180,7 +180,7 @@ class PlatformJenkinsJavaCLI(PlatformJenkins):
                 exists already, or there was some communication error.
         """
         call = subprocess.Popen(self.cli + [PlatformJenkinsJavaCLI.CREATE_JOB, job.name], stdin=subprocess.PIPE)
-        out, err = call.communicate(input=platform_ci.jjb.get_job_as_xml(job, self.template_dir))
+        out, err = call.communicate(input=platform_ci.jjb.get_job_as_xml(job, self.template_dir, self.url))
         call.wait()
         if call.returncode != 0:
             logging.info(out)
@@ -195,7 +195,7 @@ class PlatformJenkinsJavaCLI(PlatformJenkins):
                 does not exist, or there was some communication error.
         """
         call = subprocess.Popen(self.cli + [PlatformJenkinsJavaCLI.UPDATE_JOB, job.name], stdin=subprocess.PIPE)
-        call.communicate(input=platform_ci.jjb.get_job_as_xml(job, self.template_dir))
+        call.communicate(input=platform_ci.jjb.get_job_as_xml(job, self.template_dir, self.url))
         call.wait()
         if call.returncode != 0:
             raise PlatformJenkinsException("Updating job failed: " + job.name)

--- a/build-on-push/platform_ci/platform_ci/jjb.py
+++ b/build-on-push/platform_ci/platform_ci/jjb.py
@@ -24,33 +24,50 @@ import shutil
 import subprocess
 
 
-def get_job_as_xml(job, template_dir):
+def get_job_as_xml(job, template_dir, jenkins_url=None):
     """Returns a instantiated definition of a Jenkins job in XML format.
 
     Args:
         job: A Jenkins Job object to be instantiated
         template_dir: A path to a directory containing job templates
+        jenkins_url: A URL to the Jenkins instance which may be read
+            when the XML is being created (usually to get versions
+            of the plugins). If None, it will be obtained from the
+            JENKINS_URL environment variable.
 
     Returns:
         A string with the XML definition of a Jenkins job, suitable to be
             used as an input for Jenkins API to create/update a job.
+
+    Raises:
+        KeyError: If jenkins_url is None and JENKINS_URL environment variable
+            does not exist.
     """
-    with JJB(template_dir) as jjbuilder:
+    if jenkins_url is None:
+        jenkins_url = os.environ["JENKINS_URL"]
+
+    with JJB(template_dir, jenkins_url) as jjbuilder:
         jobxml = jjbuilder.get_job_as_xml(job)
     return jobxml
 
 
 # pylint: disable=too-few-public-methods
 class JJB(object):
-    def __init__(self, template_dir):
+    def __init__(self, template_dir, jenkins_url):
         self.template_dir = template_dir
         self.workdir = tempfile.mkdtemp()
+        self.jenkins_url = jenkins_url
+        filename = "config_file.ini"
+        self.config_file = os.path.join(self.workdir, filename)
 
     def __enter__(self):
         for item in os.listdir(self.template_dir):
             source_path = os.path.join(self.template_dir, item)
             if os.path.isfile(source_path):
                 shutil.copy(source_path, self.workdir)
+
+        with open(self.config_file, "w") as config_file_handler:
+            config_file_handler.write("[jenkins]\nurl={0}".format(self.jenkins_url))
 
         return self
 
@@ -61,6 +78,17 @@ class JJB(object):
         with open(os.path.join(self.workdir, "%s.yaml" % job.name), "w") as job_file:
             job_file.write(job.as_yaml())
 
-        jjb = subprocess.Popen(["jenkins-jobs", "test", self.workdir, job.name], stdout=subprocess.PIPE)
-        jjb_xml = jjb.communicate()[0]
+        to_execute = ["jenkins-jobs", "--conf", self.config_file, "test", self.workdir, job.name]
+
+        try:
+            jjb_xml = subprocess.check_output(to_execute, stderr=subprocess.PIPE)
+        except subprocess.CalledProcessError:
+            jjb_user = os.environ["JOB_BUILDER_USER"]
+            jjb_password = os.environ["JOB_BUILDER_PASS"]
+
+            with open(self.config_file, "a") as config_file_handler:
+                config_file_handler.write("\nuser={0}\npassword={1}".format(jjb_user, jjb_password))
+
+            jjb_xml = subprocess.check_output(to_execute, stderr=subprocess.PIPE)
+
         return jjb_xml

--- a/build-on-push/platform_ci/platform_ci/jjb.py
+++ b/build-on-push/platform_ci/platform_ci/jjb.py
@@ -24,31 +24,50 @@ import shutil
 import subprocess
 
 
-def get_job_as_xml(job, template_dir):
+def get_job_as_xml(job, template_dir, jenkins_url=None):
     """Returns a instantiated definition of a Jenkins job in XML format.
 
     Args:
         job: A Jenkins Job object to be instantiated
         template_dir: A path to a directory containing job templates
+        jenkins_url: A URL to the Jenkins instance which may be read
+            when the XML is being created (usually to get versions
+            of the plugins). If None, it will be obtained from the
+            JENKINS_URL environment variable.
 
     Returns:
         A string with the XML definition of a Jenkins job, suitable to be
             used as an input for Jenkins API to create/update a job.
+
+    Raises:
+        KeyError: If jenkins_url is None and JENKINS_URL environment variable
+            does not exist.
     """
-    with JJB(template_dir) as jjbuilder:
+    if jenkins_url is None:
+        jenkins_url = os.environ["JENKINS_URL"]
+
+    with JJB(template_dir, jenkins_url) as jjbuilder:
         jobxml = jjbuilder.get_job_as_xml(job)
     return jobxml
 
 
 # pylint: disable=too-few-public-methods
 class JJB(object):
-    def __init__(self, template_dir):
+    def __init__(self, template_dir, jenkins_url):
         self.template_dir = template_dir
         self.workdir = tempfile.mkdtemp()
+        self.jenkins_url = jenkins_url
+        filename = "config_file.ini"
+        self.config_file = os.path.join(self.workdir, filename)
 
     def __enter__(self):
         for item in os.listdir(self.template_dir):
-            shutil.copy(os.path.join(self.template_dir, item), self.workdir)
+            source_path = os.path.join(self.template_dir, item)
+            if os.path.isfile(source_path):
+                shutil.copy(source_path, self.workdir)
+
+        with open(self.config_file, "w") as config_file_handler:
+            config_file_handler.write("[jenkins]\nurl={0}".format(self.jenkins_url))
 
         return self
 
@@ -59,6 +78,17 @@ class JJB(object):
         with open(os.path.join(self.workdir, "%s.yaml" % job.name), "w") as job_file:
             job_file.write(job.as_yaml())
 
-        jjb = subprocess.Popen(["jenkins-jobs", "test", self.workdir, job.name], stdout=subprocess.PIPE)
-        jjb_xml = jjb.communicate()[0]
+        to_execute = ["jenkins-jobs", "--conf", self.config_file, "test", self.workdir, job.name]
+
+        try:
+            jjb_xml = subprocess.check_output(to_execute, stderr=subprocess.PIPE)
+        except subprocess.CalledProcessError:
+            jjb_user = os.environ["JOB_BUILDER_USER"]
+            jjb_password = os.environ["JOB_BUILDER_PASS"]
+
+            with open(self.config_file, "a") as config_file_handler:
+                config_file_handler.write("\nuser={0}\npassword={1}".format(jjb_user, jjb_password))
+
+            jjb_xml = subprocess.check_output(to_execute, stderr=subprocess.PIPE)
+
         return jjb_xml


### PR DESCRIPTION
To be able generate jobs, which send messages to ci message bus,
it is necessary to add config file to get_job_as_xml. The config
is created as a temporary and it contains the jenkins master
URL and credentials (if it is required). Credentials are obtained
from environment variables.