### PR TITLE
Popen instead of check_output

### DIFF
--- a/build-on-push/platform_ci/platform_ci/jjb.py
+++ b/build-on-push/platform_ci/platform_ci/jjb.py
@@ -81,7 +81,7 @@ class JJB(object):
         to_execute = ["jenkins-jobs", "--conf", self.config_file, "test", self.workdir, job.name]
 
         try:
-            jjb_xml = subprocess.check_output(to_execute, stderr=subprocess.PIPE)
+            jjb_xml = subprocess.Popen(to_execute, stderr=subprocess.PIPE)
         except subprocess.CalledProcessError:
             jjb_user = os.environ["JOB_BUILDER_USER"]
             jjb_password = os.environ["JOB_BUILDER_PASS"]
@@ -89,6 +89,6 @@ class JJB(object):
             with open(self.config_file, "a") as config_file_handler:
                 config_file_handler.write("\nuser={0}\npassword={1}".format(jjb_user, jjb_password))
 
-            jjb_xml = subprocess.check_output(to_execute, stderr=subprocess.PIPE)
+            jjb_xml = subprocess.Popen(to_execute, stderr=subprocess.PIPE)
 
         return jjb_xml


### PR DESCRIPTION
this is needed, because check_output is in python-2.7.0 or newer,
but BaseOS-CI master is RHEL-6 with python-2.6.6.

This is breaking BaseOS-CI completely, please fix this ASAP