### PR TITLE
Replacing check_call() with Popen() lacks communicate()

### DIFF
--- a/build-on-push/platform_ci/platform_ci/jjb.py
+++ b/build-on-push/platform_ci/platform_ci/jjb.py
@@ -81,7 +81,7 @@ class JJB(object):
         to_execute = ["jenkins-jobs", "--conf", self.config_file, "test", self.workdir, job.name]
 
         try:
-            jjb_xml = subprocess.Popen(to_execute, stderr=subprocess.PIPE)
+            jjb_xml = subprocess.Popen(to_execute, stderr=subprocess.PIPE).communicate()[0]
         except subprocess.CalledProcessError:
             jjb_user = os.environ["JOB_BUILDER_USER"]
             jjb_password = os.environ["JOB_BUILDER_PASS"]
@@ -89,6 +89,6 @@ class JJB(object):
             with open(self.config_file, "a") as config_file_handler:
                 config_file_handler.write("\nuser={0}\npassword={1}".format(jjb_user, jjb_password))
 
-            jjb_xml = subprocess.Popen(to_execute, stderr=subprocess.PIPE)
+            jjb_xml = subprocess.Popen(to_execute, stderr=subprocess.PIPE).communicate()[0]
 
         return jjb_xml


### PR DESCRIPTION
Fixes insufficient c6a03dc51b93d284159fce3e5bc02b438dd404d9.

Replacing unsupported check_call() by Popen() is not enough - suddenly,
resulting variable is not a string but Popen instance. Adding
communicate()[0] to get stdout should complete the fix.