### PR TITLE
Fixing Popen in JJB

### DIFF
--- a/build-on-push/platform_ci/platform_ci/jjb.py
+++ b/build-on-push/platform_ci/platform_ci/jjb.py
@@ -80,15 +80,15 @@ class JJB(object):
 
         to_execute = ["jenkins-jobs", "--conf", self.config_file, "test", self.workdir, job.name]
 
-        try:
-            jjb_xml = subprocess.Popen(to_execute, stderr=subprocess.PIPE).communicate()[0]
-        except subprocess.CalledProcessError:
+        jjb_xml = subprocess.Popen(to_execute, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[0]
+
+        if not jjb_xml:
             jjb_user = os.environ["JOB_BUILDER_USER"]
             jjb_password = os.environ["JOB_BUILDER_PASS"]
 
             with open(self.config_file, "a") as config_file_handler:
                 config_file_handler.write("\nuser={0}\npassword={1}".format(jjb_user, jjb_password))
 
-            jjb_xml = subprocess.Popen(to_execute, stderr=subprocess.PIPE).communicate()[0]
+            jjb_xml = subprocess.Popen(to_execute, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[0]
 
         return jjb_xml


### PR DESCRIPTION
Adding parameter stdout=subprocess.PIPE to Popen(), so the output is string now.
Determination of error in Popen call changed to simple check of empty output.