### PR TITLE
Calling jenkins job builder with no config file

### DIFF
--- a/build-on-push/jjb/platform-commit.yaml
+++ b/build-on-push/jjb/platform-commit.yaml
@@ -68,9 +68,6 @@
             job-commit-dispatcher.sh "{component}" "$GIT_BRANCH" "{github-user}" "{platform-ci-branch}"
     wrappers:
         - default-ci-workflow-wrappers
-        - inject-passwords:
-            global: true
-            mask-password-params: true
 
 - job-template:
     name: 'ci-{component}-dispatcher-commit'


### PR DESCRIPTION
I come with better solution for issue #41. Instead of injecting password to all
jobs, which update or create some other job, I change the way how xml for
updating/creating job is obtained from source yaml file.

In case jekins job builder does not need access to Jenkins instance, it is called
without any config file.