### PR TITLE
[MVP] adding support for ci-metricsdata in job defaults

### DIFF
--- a/MVP/defaults-build.yaml
+++ b/MVP/defaults-build.yaml
@@ -69,7 +69,7 @@
                   "create_time": "",
                   "tests": $TESTS,
                   "CI_tier": "1",
-                  "owner_mtr": "$job_owner",
+                  "owner": "$job_owner",
                   "build_type": "",
                   "base_distro": "",
                   "completion_time": "",

--- a/MVP/defaults-build.yaml
+++ b/MVP/defaults-build.yaml
@@ -1,6 +1,6 @@
 - defaults:
     name: defaults-build
-    node: 'jslave-platform-rhel7'
+    node: 'jslave-platform'
     parameters:
         - string:
             name: id
@@ -34,17 +34,58 @@
                 - shell: |
                     echo "Jenkins job failed or canceled - canceling any submitted Beaker jobs"
                     bkr job-cancel ${{BKR_JOBID}}
+        - postbuildscript:
+            script-only-if-succeeded: False
+            builders:
+                - shell: |
+                    BKR_JOBID_NUM=`echo ${{BKR_JOBID//J:/}}`
+                    echo "BKR_JOBID_NUM=${{BKR_JOBID_NUM// /+}}" >> $WORKSPACE/job.properties
+                    BKR_TESTS_EXEC=0
+                    BKR_TESTS_FAILED=0
+                    for jobid in $BKR_JOBID; do
+                      bkr job-results --format junit-xml $jobid > $WORKSPACE/$jobid.xml
+                      for testsuite in $(grep hostname $WORKSPACE/$jobid.xml); do
+                        echo $testsuite | grep tests= && BKR_TESTS_EXEC=$((BKR_TESTS_EXEC+$(echo $testsuite | cut -d'"' -f2)))
+                        echo $testsuite | grep failures= && BKR_TESTS_FAILED=$((BKR_TESTS_FAILED+$(echo $testsuite | cut -d'"' -f2)))
+                      done
+                    done
+                    echo "BKR_TESTS_EXEC=$BKR_TESTS_EXEC" >> $WORKSPACE/job.properties
+                    echo "BKR_TESTS_FAILED=$BKR_TESTS_FAILED" >> $WORKSPACE/job.properties
+                    TESTS=('[{{"executor": "beaker", "arch": "'"$ARCH"'", "executed": "'"$BKR_TESTS_EXEC"'", "failed": "'"$BKR_TESTS_FAILED"'"}}]')
+                    echo "TESTS=$TESTS" >> $WORKSPACE/job.properties
+                - inject:
+                    properties-file: $WORKSPACE/job.properties
         - archive:
             artifacts: '*.txt, *.xml, *.properties'
             allow-empty: 'true'
         - junit:
             results: 'J:*.xml'
+        - ci-publisher:
+            message-type: 'Tier1TestingDone'
+            message-properties: |
+                CI_TYPE=ci-metricsdata
+            message-content: |
+                {{
+                  "create_time": "",
+                  "tests": $TESTS,
+                  "CI_tier": "1",
+                  "owner_mtr": "$job_owner",
+                  "build_type": "",
+                  "base_distro": "",
+                  "completion_time": "",
+                  "component": "$name-$version-$release",
+                  "jenkins_job_url": "$JOB_URL",
+                  "jenkins_build_url": "$BUILD_URL",
+                  "brew_task_id": "$task_id",
+                  "job_names": "$JOB_NAME",
+                  "xunit_links": ""
+                }}
         - email-ext:
             recipients: ${{OWNERSHIP,var="JOB_COOWNERS_EMAILS"}}
-            subject: $DEFAULT_SUBJECT [${{ENV,var="BUILD"}}] (${{TEST_COUNTS,var="fail"}}/${{TEST_COUNTS}})
+            subject: $DEFAULT_SUBJECT [${{ENV,var="name"}}-${{ENV,var="version"}}-${{ENV,var="release"}}] (${{TEST_COUNTS,var="fail"}}/${{TEST_COUNTS}})
             body: |
                 $DEFAULT_CONTENT
-                More details at ${{ENV,var="JOB_DETAIL"}}
+                Job details at https://beaker.engineering.redhat.com/matrix/?job_ids=${{ENV,var="BKR_JOBID_NUM"}}
             always: true
             failure: false
             send-to:

--- a/MVP/sample_job.yaml
+++ b/MVP/sample_job.yaml
@@ -5,37 +5,36 @@
     properties:
         - ownership:
             owner: your_ID
+            co-owners:
+                - teammate1_ID
+                - teammate2_ID
     triggers:
         - ci-trigger:
-            # Job trigger for only official builds in brew
+            # Sample job trigger for official Brew builds
+            # Build NVR in $name $version $release
             jms-selector: "name = '{component}' AND CI_TYPE = 'brew-tag' AND tag LIKE '%-candidate'"
 
-            # Job trigger for only scratch builds in brew
+            # Sample job trigger for scratch Brew builds
             #jms-selector: "name = '{component}' AND CI_TYPE = 'brew-taskstatechange' AND scratch = true"
 
-            # Job trigger for stable compose that passed RTT validation
+            # Sample job trigger for RTT_Accepted compose - other parameters may turn different in this case
+            # Compose ID in $BUILD
             #jms-selector: "CI_NAME='rtt-accepted-publisher'"
     builders:
         - shell: |
             #!/bin/bash -x
+
             # Here goes your shell commands for submitting beaker job here, and save the job ID into env var BKR_JOBID. E.g:
             bkr job-submit $YOUR_TEST_xml | tee $WORKSPACE/bkr_job.txt
             BKR_JOBID=`cut -d\' -f2 $WORKSPACE/bkr_job.txt`
 
-            # Saving the Beaker job IDs to file job.properties
             echo BKR_JOBID=$BKR_JOBID > $WORKSPACE/job.properties
-            BKR_JOBID_NUM=`echo ${{BKR_JOBID//J:/}}`
-            echo JOB_DETAIL="https://beaker.engineering.redhat.com/matrix/?job_ids=${{BKR_JOBID_NUM// /+}}" >> $WORKSPACE/job.properties
-            echo BUILD=${{BUILD:-$name-$version-$release}} >> $WORKSPACE/job.properties
         - inject:
             properties-file: $WORKSPACE/job.properties
         - shell: |
             #!/bin/bash -x
-            # Here goes the shell command to watch your Beaker jobs and format results on completion
             bkr job-watch $BKR_JOBID
-            for jobid in $BKR_JOBID; do
-              bkr job-results --format junit-xml $jobid > $WORKSPACE/$jobid.xml
-            done
+            echo $?
 
 - project:
     name: Platform-CI-MVP


### PR DESCRIPTION
Tested and passed with sample job(sample-Platform-CI-MVP) on pjm-stg.

This PR will not affect current MVP workflow - only adding an extra postbuild step (and some trivial polishing work) for sending out ci-metrics message to the hub.