### PR TITLE
Add missing jenkins build url.

### DIFF
--- a/ci-metrics/README.md
+++ b/ci-metrics/README.md
@@ -159,6 +159,7 @@ The possible items of the message are defined in this document [https://url.corp
                 "completion_time": "$COMPLETION_TIME",
                 "component": "$name-$version-$release",
                 "jenkins_job_url": "$JOB_URL",
+                "jenkins_build_url": "$BUILD_URL",
                 "brew_task_id": "$id",
                 "job_names": "$JOB_NAME",
                 "xunit_links": "$XUNIT_LINKS"


### PR DESCRIPTION
This was added to the confluence spec later on.  It appears in the
``MVP/defaults-build.yaml`` file, but was forgotten from
``ci-metrics/README.md``.