### PR TITLE
Update ci_listener.py to allow compose messages

### DIFF
--- a/ci-metrics/ci_listener.py
+++ b/ci-metrics/ci_listener.py
@@ -280,7 +280,7 @@ class MetricsParser(Parser):
                   'tests' : self.handle_tests,
                   'jenkins_job_url' : self.handle_simple,
                   'base_distro' : self.handle_simple256,
-                  'compose_id' : self.handle_digit,
+                  'compose_id' : self.handle_simple256,
                   'create_time' : self.handle_time,
                   'completion_time' : self.handle_time,
                   'CI_infra_failure' : self.handle_simple,

--- a/ci-metrics/ci_listener.py
+++ b/ci-metrics/ci_listener.py
@@ -187,8 +187,15 @@ class MetricsParser(Parser):
                               '(0[0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9])Z')
 
     def get_docid(self):
-        docid = "%s-%s" % (self.message_in.get("component"),
-                           str(self.message_in.get("brew_task_id")))
+        component = self.message_in.get("component")
+        brew_task_id = self.message_in.get("brew_task_id")
+        compose_id = self.message_in.get("compose_id")
+        if component and brew_task_id:
+            docid = "%s-%s" % ( component, brew_task_id)
+        elif compose_id:
+            docid = "%s" % compose_id
+        else:
+            docid = None
         return docid
 
     def handle_component(self, key, value, retried=False):

--- a/ci-metrics/ci_listener.py
+++ b/ci-metrics/ci_listener.py
@@ -83,19 +83,20 @@ class Parser(object):
     def get_docid(self):
         raise NotImplementedError()
 
-    @classmethod
-    def check_type(cls, ci_type):
-        return ci_type == cls.CI_TYPE
-
 class BrewParser(Parser):
-    CI_TYPE = "brew-taskstatechange"
-
     time_format = re.compile(r'(\d{4})-(0[1-9]|1[0-2])-'
                               '(0[1-9]|1[0-9]|2[0-9]|3[01]) '
                               '(0[0-9]|1[0-9]|2[0-3]):'
                               '(0[0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9]):'
                               '(0[0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9]).'
                               '[0-9][0-9][0-9][0-9][0-9][0-9]')
+
+    @classmethod
+    def is_valid(cls, message_in, options):
+        ci_type = os.environ.get("CI_TYPE", None) \
+                                  if options.ci_type is None \
+                                        else options.ci_type
+        return ci_type == "brew-taskstatechange"
 
     def get_name(self):
         return os.environ.get("name", None) \
@@ -178,17 +179,24 @@ class BrewParser(Parser):
         return self.message_out
 
 class MetricsParser(Parser):
-    CI_TYPE = "ci-metricsdata"
-
     # ISO8601 regex.  We use this for metrics timestamps
     time_format = re.compile(r'(\d{4})-(0[1-9]|1[0-2])-(0[1-9]|1[0-9]|2[0-9]|3[01])'
                               '(|[tT\s])(0[0-9]|1[0-9]|2[0-3]):'
                               '(0[0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9]):'
                               '(0[0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9])Z')
 
+    @classmethod
+    def is_valid(cls, message_in, options):
+        ci_type = os.environ.get("CI_TYPE", None) \
+                                  if options.ci_type is None \
+                                        else options.ci_type
+        return ci_type == "ci-metricsdata" and \
+               message_in.get("component") != None and \
+               message_in.get("brew_task_id") != None
+
     def get_docid(self):
         docid = "%s-%s" % (self.message_in.get("component"),
-                           str(self.message_in.get("brew_task_id")))
+                           self.message_in.get("brew_task_id"))
         return docid
 
     def handle_component(self, key, value, retried=False):
@@ -325,11 +333,8 @@ class ParserManager(object):
         self.message_out = self.get_log()
 
     def choose_parser_engine(self):
-        ci_type = os.environ.get("CI_TYPE", None) \
-                                  if self.options.ci_type is None \
-                                        else self.options.ci_type
         for parser in Parser.__subclasses__():
-            if parser.check_type(ci_type):
+            if parser.is_valid(self.message_in, self.options):
                 return parser(self.message_in, self.options)
 
     def get_docid(self):


### PR DESCRIPTION
ci-metricsdata messages can be either component or compose based.  This change allows compose messages to be stored.