### PR TITLE
Add 'name' as its own field in elasticsearch logs

### DIFF
--- a/ci-metrics/ci_listener.py
+++ b/ci-metrics/ci_listener.py
@@ -338,6 +338,9 @@ class MetricsParser(Parser):
 
         # Add field that shows CI Testing was done for kibana visualizations
         self.message_out['CI Testing Done'] = 'true'
+        # Add name as its own field so we can count how many
+        # unique package names have come in
+        self.message_out["name"] = self.message_in["component"].split('-')[:-2]
         # Convert message_in dict to array of tuples.
         # Items can come in any order but some handle routines
         # need data that may not have been handled yet.

--- a/ci-metrics/ci_listener.py
+++ b/ci-metrics/ci_listener.py
@@ -340,7 +340,7 @@ class MetricsParser(Parser):
         self.message_out['CI Testing Done'] = 'true'
         # Add name as its own field so we can count how many
         # unique package names have come in
-        self.message_out["name"] = self.message_in["component"].split('-')[:-2]
+        self.message_out["name"] = '-'.join(self.message_in["component"].split('-')[:-2])
         # Convert message_in dict to array of tuples.
         # Items can come in any order but some handle routines
         # need data that may not have been handled yet.

--- a/ci-metrics/ci_listener.py
+++ b/ci-metrics/ci_listener.py
@@ -302,7 +302,7 @@ class MetricsParser(Parser):
         recipient_set = Set()
         if "recipients" in self.message_out:
             recipient_set.update(map(lambda x: x.strip(), \
-            message_out.get("recipients","").split(",")))
+            self.message_out.get("recipients","").split(",")))
 
         # Add new recipients to the set
         recipient_set.update(value)


### PR DESCRIPTION
This change pushes "name" as its own field to the elasticsearch logs, separate from NVR.  This allows querying name much more easily in kibana, as splitting nvr and querying that in Kibana is not easy in my opinion.