### PR TITLE
Rename job_names to job_name

### DIFF
--- a/ci-metrics/README.md
+++ b/ci-metrics/README.md
@@ -162,6 +162,7 @@ The possible items of the message are defined in this document [https://url.corp
                 "jenkins_build_url": "$BUILD_URL",
                 "brew_task_id": "$id",
                 "job_name": "$JOB_NAME",
+                "recipients": "someuser"
             }}
 ```
 

--- a/ci-metrics/README.md
+++ b/ci-metrics/README.md
@@ -161,8 +161,7 @@ The possible items of the message are defined in this document [https://url.corp
                 "jenkins_job_url": "$JOB_URL",
                 "jenkins_build_url": "$BUILD_URL",
                 "brew_task_id": "$id",
-                "job_names": "$JOB_NAME",
-                "xunit_links": "$XUNIT_LINKS"
+                "job_name": "$JOB_NAME",
             }}
 ```
 

--- a/ci-metrics/ci_listener.py
+++ b/ci-metrics/ci_listener.py
@@ -264,8 +264,11 @@ class MetricsParser(Parser):
                     tester["executed"] = -1
                 if not isinstance(tester["failed"], int):
                     tester["failed"] = -1
-                if not isinstance(tester["passed"], int):
-                    tester["passed"] = -1
+                if "passed" in tester:
+                    if not isinstance(tester["passed"], int):
+                        tester["passed"] = -1
+                else:
+                    tester["passed"] = tester["executed"] - tester["failed"]
                 start = self.message_out.get("create_time",
                                              "2000-01-01T00:00:00Z")
                 end = self.message_out.get("completion_time",
@@ -284,6 +287,8 @@ class MetricsParser(Parser):
                     (executor, next_slot)] = tester["executed"]
                 self.message_out["%s_tests_failed_%s" %
                     (executor, next_slot)] = tester["failed"]
+                self.message_out["%s_tests_passed_%s" %
+                    (executor, next_slot)] = tester["passed"]
                 self.message_out["%s_time_spent_%s" %
                     (executor, next_slot)] = seconds
                 # Create some aggregated fields so that they

--- a/ci-metrics/ci_listener.py
+++ b/ci-metrics/ci_listener.py
@@ -256,8 +256,8 @@ class MetricsParser(Parser):
             executor = tester["executor"]
             next_slot = self.find_next_slot(executor)
             if executor in valid_executors:
-                if "job_names" in self.message_in.keys():
-                    job_name = self.message_in["job_names"]
+                if "job_name" in self.message_in.keys():
+                    job_name = self.message_in["job_name"]
                 else:
                     job_name = "MISSING_JOB_NAME_%s" % next_slot
                 if not tester["executed"].isdigit():
@@ -322,7 +322,7 @@ class MetricsParser(Parser):
                   'completion_time' : self.handle_time,
                   'CI_infra_failure' : self.handle_simple,
                   'CI_infra_failure_desc' : self.handle_simple1024,
-                  'job_names' : self.handle_simple256,
+                  'job_name' : self.handle_simple256,
                   'CI_tier' : self.handle_digit,
                   'build_type' : self.handle_build_type,
                   'owner' : self.handle_simple64,
@@ -512,7 +512,7 @@ class ParseCIMetricTests(unittest.TestCase):
                           "jenkins_job_url": "https://platform-stg-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/kernel-general-rhel-kmod/",
                           "jenkins_build_url": "https://platform-stg-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/kernel-general-rhel-kmod/272/",
                           "brew_task_id": "12388882",
-                          "job_names": "kernel-general-rhel-kmod",
+                          "job_name": "kernel-general-rhel-kmod",
                           "recipients": ["jbieren", "bpeck"]
                         }
                      """

--- a/ci-metrics/ci_listener.py
+++ b/ci-metrics/ci_listener.py
@@ -509,8 +509,8 @@ class ParseCIMetricTests(unittest.TestCase):
                           "base_distro": "",
                           "completion_time": "2016-08-18T20:52:10Z",
                           "component": "kernel-3.10.0-547.el7",
-                          "jenkins_job_url": "https://platform-stg-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/kernel-general-rhel-kmod/",
-                          "jenkins_build_url": "https://platform-stg-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/kernel-general-rhel-kmod/272/",
+                          "jenkins_job_url": "https://platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/kernel-general-rhel-kmod/",
+                          "jenkins_build_url": "https://platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/kernel-general-rhel-kmod/272/",
                           "brew_task_id": "12388882",
                           "job_name": "kernel-general-rhel-kmod",
                           "recipients": ["jbieren", "bpeck"]

--- a/ci-metrics/jjb_metrics_snippets.txt
+++ b/ci-metrics/jjb_metrics_snippets.txt
@@ -84,6 +84,5 @@
                 "jenkins_job_url": "$JOB_URL",
                 "jenkins_build_url": "$BUILD_URL",
                 "brew_task_id": "$id",
-                "job_names": "$JOB_NAME",
-                "xunit_links": "$XUNIT_LINKS"
+                "job_name": "$JOB_NAME",
             }}

--- a/ci-metrics/jjb_metrics_snippets.txt
+++ b/ci-metrics/jjb_metrics_snippets.txt
@@ -86,4 +86,5 @@
                 "jenkins_build_url": "$BUILD_URL",
                 "brew_task_id": "$id",
                 "job_name": "$JOB_NAME",
+                "recipients": "someuser"
             }}

--- a/ci-metrics/jjb_metrics_snippets.txt
+++ b/ci-metrics/jjb_metrics_snippets.txt
@@ -30,12 +30,13 @@
             XUNIT_LINKS="$XUNIT_LINKS $JOB_URL/$BUILD_NUMBER/artifact/${{recipeSet}}_xUnit.xml"
         XUNIT_LINKS=$(echo "$XUNIT_LINKS" | tail -c +2)
         done
+        BKR_TESTS_PASSED=$((BKR_TESTS_EXEC-BKR_TESTS_FAILED))
         ARCH=''
         for myArch in $(bkr job-results $JOBID | xsltproc ./kernel/jenkins/helpers/job2metric.xsl - 2>&1 >/dev/null | cut -d ':' -f3 | sed -e 's/^[ \t]*//' | sort | uniq) ; do
             ARCH="$ARCH $myArch"
         done
         ARCH=${{ARCH:1:256}}
-        TESTS=('[{{"executor": "beaker", "arch": "'"$ARCH"'", "executed": "'$BKR_TESTS_EXEC'", "failed": "'$BKR_TESTS_FAILED'"}}]')
+        TESTS=('[{{"executor": "beaker", "arch": "'"$ARCH"'", "subtest": "foobar", "executed": $BKR_TESTS_EXEC, "failed": $BKR_TESTS_FAILED, "passed": $BKR_TESTS_PASSED}}]')
         CI_TIER=0
         if [[ -z $job_group ]] ; then OWNER=$job_group ; else OWNER=$owner ; fi
         if [[ "$scratch" = true ]] ; then BUILD=scratch ; else BUILD=official ; fi


### PR DESCRIPTION
The message definition has renamed the 'job_names' field to 'job_name'  

This PR updates the listener to do the same as well as updating the docs.