### PR TITLE
[CI-Metrics] Add package diff pusher

### DIFF
--- a/ci-metrics/ci_listener.py
+++ b/ci-metrics/ci_listener.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from __future__ import print_function
 import sys
 import os

--- a/ci-metrics/install_elk.yaml
+++ b/ci-metrics/install_elk.yaml
@@ -1,26 +1,14 @@
 ## This playbook sets up a basic ELK instance.  After execution,
 ## you will still need to create an index on the ELK instance
 ## and send logs to the ELK instance
+#
+## Note: To change kibana default loading page, modify
+## kibana.defaultAppId: in /etc/kibana/kibana.yml. Example:
+## kibana.defaultAppId: "dashboard/82470720-8e6a-11e7-bf16-955fd84ff7f6"
 
 - hosts: localhost
   remote_user: root
   tasks:
-  - name: Install wget
-    yum:
-      name: wget
-      state: latest
-  - name: wget the java jdk
-    shell: 'wget --no-cookies --no-check-certificate --header "Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie" "http://download.oracle.com/otn-pub/java/jdk/8u73-b02/jdk-8u73-linux-x64.rpm"'
-    args:
-      chdir: /root
-  - name: yum localinstall the java jdk
-    yum:
-      name: /root/jdk-8u73-linux-x64.rpm
-      state: present
-  - name: Remove the java jdk
-    file:
-      path: /root/jdk-8u73-linux-x64.rpm
-      state: absent
   - name: Insert elk repo
     blockinfile:
       dest: /etc/yum.repos.d/elk.repo
@@ -32,18 +20,22 @@
         gpgcheck=1
         gpgkey=https://packages.elastic.co/GPG-KEY-elasticsearch
         enabled=1
-        [kibana-4.5]
-        name=Kibana repository for 4.5.x packages
-        baseurl=http://packages.elastic.co/kibana/4.5/centos
+        [kibana-5.x]
+        name=Kibana repository for 5.x packages
+        baseurl=https://artifacts.elastic.co/packages/5.x/yum
         gpgcheck=1
-        gpgkey=http://packages.elastic.co/GPG-KEY-elasticsearch
+        gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
         enabled=1
-        [elasticsearch-2.x]
-        name=Elasticsearch repository for 2.x packages
-        baseurl=http://packages.elastic.co/elasticsearch/2.x/centos
+        autorefresh=1
+        type=rpm-md
+        [elasticsearch-5.x]
+        name=Elasticsearch repository for 5.x packages
+        baseurl=https://artifacts.elastic.co/packages/5.x/yum
         gpgcheck=1
-        gpgkey=http://packages.elastic.co/GPG-KEY-elasticsearch
+        gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
         enabled=1
+        autorefresh=1
+        type=rpm-md
         [Epel]
         name=epel
         baseurl=http://dl.fedoraproject.org/pub/epel/7/x86_64/
@@ -63,6 +55,7 @@
      - epel-release
      - nginx
      - httpd-tools
+     - java
   - name: Change elasticsearch network host
     replace:
       dest: /etc/elasticsearch/elasticsearch.yml
@@ -70,11 +63,6 @@
       replace: ' network.host{{ ":" }} 0.0.0.0'
   - name: Need selinux to be permissive
     shell: setenforce 0
-  - name: Change kibana server host
-    replace:
-      dest: /opt/kibana/config/kibana.yml
-      regexp: '# server.host{{ ":" }} "0.0.0.0"'
-      replace: ' server.host{{ ":" }} "localhost"'
   - name: Put better nginx conf file in place
     template:
       dest: /etc/nginx/nginx.conf

--- a/ci-metrics/missing_packages_updater.py
+++ b/ci-metrics/missing_packages_updater.py
@@ -8,6 +8,7 @@
 # key for each package name is provided by the user.  Finally, it
 # pushes a log depicting the percent of the packages that have coverage
 # in localhost's elasticsearch instance.
+# Author: Johnny Bieren <jbieren@redhat.com>
 
 from __future__ import division
 from optparse import OptionParser

--- a/ci-metrics/missing_packages_updater.py
+++ b/ci-metrics/missing_packages_updater.py
@@ -1,0 +1,102 @@
+#!/usr/bin/python
+
+# This script takes in a package list, a field name, and a distro.
+# It then pushes logs to localhost's instance of elasticsearch
+# on port 9200 for every package in the provided list that is not
+# present in the name.raw bucket of localhost's elasticsearch.
+# It also includes the provided distro for each said log. The field
+# key for each package name is provided by the user.  Finally, it
+# pushes a log depicting the percent of the packages that have coverage
+# in localhost's elasticsearch instance.
+
+from __future__ import division
+from optparse import OptionParser
+import json
+import sys
+import httplib
+import time
+
+def line_count(myfile):
+    i = 0
+    with open(myfile) as f:
+        for i in enumerate(f, 1):
+            pass
+    return(i[0])
+
+def num_pkgs_not_tested(myfile, distro, mykey):
+    query = '''
+    {
+        "aggs" : {
+            "name.raw" : {
+                "terms" : {
+                    "field": "name.raw", 
+                    "size": 200
+                }
+            }
+        }
+    }'''
+    i = 0
+    local_server = httplib.HTTPConnection('localhost:9200')
+    local_server.request("POST", "/ci-metrics/_search?size=0", query)
+    reply = local_server.getresponse()
+    json_in = reply.read()
+    namesjson = json.loads(json_in)
+    tested_pkgs = []
+    for name in namesjson['aggregations']['name.raw']['buckets']:
+        if len(name['key']) > 1:
+            tested_pkgs.append(json.dumps(name['key']).strip("\""))
+    # Push a log with package name and distro for each package not tested
+    with open(myfile) as f:
+        for key in f.read().splitlines():
+            if key not in tested_pkgs:
+                i = i + 1
+                message_out = dict()
+                message_out[mykey] = key
+                message_out['timestamp'] = int(time.time())*1000
+                message_out['base_distro'] = distro
+                message_out['CI Testing Done'] = 'false'
+                push_log(message_out)
+    return i
+
+def push_log(mymessage):
+    output = json.dumps(mymessage, indent=4)
+    local_server = httplib.HTTPConnection('localhost:9200')
+    local_server.request("POST", "/ci-metrics/log/", output)
+    reply = local_server.getresponse()
+    data = reply.read()
+    if reply.status not in [200, 201]:
+        print("Failed to push log data to Elastic Search."
+              " Status:%s Reason:%s" % (reply.status, reply.reason))
+
+def main(args):
+    if sys.version_info < (2,5):
+        eprint("Python 2.5 or better is required.")
+        sys.exit(1)
+
+    # Parse the command line args
+    usage = 'usage: %prog'
+    parser = OptionParser()
+    parser.add_option('-f', '--file', dest='myfile', default=None,
+                      help='File in $pwd containing list of packages to compare with')
+    parser.add_option('-d', '--distro', dest='mydistro', default=None,
+                      help='Distro to populate base_distro with in logs')
+    parser.add_option('-k', '--key', dest='mykey', default=None,
+                      help='Field key name to use to store the untested package name in elasticsearch')
+
+    options, arguments = parser.parse_args(args)
+
+    if options.myfile is None or options.mydistro is None or options.mykey is None:
+        print("You must provide a package file and a distro.")
+        sys.exit(1)
+    
+    message_out = dict()
+    totalpackages = line_count(options.myfile)
+    not_tested = num_pkgs_not_tested(options.myfile, options.mydistro, options.mykey)
+    percent_key = options.mykey.replace('_not', '') + '_percent'
+    message_out[percent_key] = (float((totalpackages - not_tested) / totalpackages * 100))
+    message_out['base_distro'] = options.mydistro
+    message_out['timestamp'] = int(time.time())*1000
+    push_log(message_out)
+
+if __name__ == '__main__':
+    main(sys.argv[1:])


### PR DESCRIPTION
- Update ci_listener.py to use /usr/bin/python as that is now best practices now
- Update install_elk.yaml to latest kibana/elasticsearch versions
- Add missing_packages_updater.py.  This script takes a list of packages and queries localhost's elasticsearch instance to find out which of those packages have no test coverage.  It then pushes a log for each uncovered package, as well as a log depicting the percent of the packages which have coverage.  