### PR TITLE
Fix nvr bug

### DIFF
--- a/ci-metrics/ci_listener.py
+++ b/ci-metrics/ci_listener.py
@@ -205,7 +205,7 @@ class MetricsParser(Parser):
     def handle_component(self, key, value, retried=False):
         if value.count('-') < 2:
             eprint("BAD NVR: %s" % value)
-            self.message_out["nvr"] = value[:256]
+        self.message_out["nvr"] = value[:256]
         return True
 
     def handle_brew_task_id(self, key, value, retried=False):


### PR DESCRIPTION
Not sure when this was introduced, but this makes it so there is only an NVR field if there is a badly formatted NVR given, which is obviously very bad.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>